### PR TITLE
Issue #937: Mitigate XXE attacks

### DIFF
--- a/src/Import/XPathParser.php
+++ b/src/Import/XPathParser.php
@@ -30,6 +30,7 @@ class XPathParser
     public function __construct($xmlString)
     {
         libxml_clear_errors();
+        libxml_disable_entity_loader(true);
         $internal = libxml_use_internal_errors(true);
 
         $this->document = new \DOMDocument;

--- a/src/Import/XmlParser/CatalogXmlParser.php
+++ b/src/Import/XmlParser/CatalogXmlParser.php
@@ -50,6 +50,7 @@ class CatalogXmlParser
      */
     public static function fromFilePath($sourceFilePath, Logger $logger)
     {
+        libxml_disable_entity_loader(true);
         self::validateSourceFilePathIsString($sourceFilePath);
         self::validateSourceFileExists($sourceFilePath);
         self::validateSourceFileIsReadable($sourceFilePath);
@@ -65,6 +66,7 @@ class CatalogXmlParser
      */
     public static function fromXml($xmlString, Logger $logger)
     {
+        libxml_disable_entity_loader(true);
         self::validateSourceXmlIsString($xmlString);
         $xmlReader = new \XMLReader();
         $xmlReader->XML($xmlString);


### PR DESCRIPTION
Issue #937: Disable external entity processing in libxml before processing XML to mitigate XXE attacks.

Don't merge yet, lets wait until the PHP7 PR is complete and then I'll rebase and then it can be merged.