### PR TITLE
Issue: #964: Don't throw an exception in case REST API call has no "Accept" header

### DIFF
--- a/src/Http/HttpRequest.php
+++ b/src/Http/HttpRequest.php
@@ -30,7 +30,7 @@ abstract class HttpRequest
      */
     private $body;
 
-    final public function __construct(HttpUrl $url, HttpHeaders $headers, HttpRequestBody $body)
+    private function __construct(HttpUrl $url, HttpHeaders $headers, HttpRequestBody $body)
     {
         $this->url = $url;
         $this->headers = $headers;
@@ -87,6 +87,11 @@ abstract class HttpRequest
     public function getPathWithWebsitePrefix() : string
     {
         return $this->getUrl()->getPathWithWebsitePrefix();
+    }
+
+    public function hasHeader(string $headerName) : bool
+    {
+        return $this->headers->has($headerName);
     }
 
     public function getHeader(string $headerName) : string

--- a/src/RestApi/ApiRouter.php
+++ b/src/RestApi/ApiRouter.php
@@ -34,10 +34,9 @@ class ApiRouter implements HttpRouter
             return null;
         }
 
-        $acceptHeader = $request->getHeader('Accept');
-        if (!preg_match(
+        if (! $request->hasHeader('Accept') || ! preg_match(
             '/^application\/vnd\.lizards-and-pumpkins\.\w+\.v(\d+)\+(?:json|xml)$/',
-            $acceptHeader,
+            $request->getHeader('Accept'),
             $matchedVersion
         )) {
             return null;

--- a/tests/Unit/Suites/Http/AbstractHttpRequestTest.php
+++ b/tests/Unit/Suites/Http/AbstractHttpRequestTest.php
@@ -264,4 +264,23 @@ abstract class AbstractHttpRequestTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertSame('example.com', $request->getHost());
     }
+
+    public function testDelegatesCheckingIfHeaderExistsToHttpHeaders()
+    {
+        $headerName = 'foo';
+
+        $stubHttpUrl = $this->createMock(HttpUrl::class);
+
+        $stubHttpHeaders = $this->createMock(HttpHeaders::class);
+        $stubHttpHeaders->method('has')->with($headerName)->willReturn(true);
+
+        $httpRequest = HttpRequest::fromParameters(
+            HttpRequest::METHOD_GET,
+            $stubHttpUrl,
+            $stubHttpHeaders,
+            new HttpRequestBody('')
+        );
+
+        $this->assertTrue($httpRequest->hasHeader($headerName));
+    }
 }

--- a/tests/Unit/Suites/RestApi/ApiRouterTest.php
+++ b/tests/Unit/Suites/RestApi/ApiRouterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\RestApi;
 
+use LizardsAndPumpkins\Http\Exception\HeaderNotPresentException;
 use LizardsAndPumpkins\Http\HttpRequest;
 
 /**
@@ -45,6 +46,7 @@ class ApiRouterTest extends \PHPUnit_Framework_TestCase
 
     public function testNullIsReturnedIfVersionFormatIsInvalid()
     {
+        $this->stubHttpRequest->method('hasHeader')->with('Accept')->willReturn(true);
         $this->stubHttpRequest->method('getHeader')->with('Accept')->willReturn('application/json');
         $this->stubHttpRequest->method('getPathWithoutWebsitePrefix')->willReturn('api/foo');
         $result = $this->apiRouter->route($this->stubHttpRequest);
@@ -52,8 +54,19 @@ class ApiRouterTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($result);
     }
 
+    public function testReturnsNullIfRequestHasNoAcceptHeader()
+    {
+        $this->stubHttpRequest->method('hasHeader')->with('Accept')->willReturn(false);
+        $this->stubHttpRequest->method('getHeader')->with('Accept')->willThrowException(new HeaderNotPresentException);
+        $this->stubHttpRequest->method('getPathWithoutWebsitePrefix')->willReturn('api');
+        $result = $this->apiRouter->route($this->stubHttpRequest);
+
+        $this->assertNull($result);
+    }
+
     public function testNullIsReturnedIfEndpointCodeIsNotSpecified()
     {
+        $this->stubHttpRequest->method('hasHeader')->with('Accept')->willReturn(true);
         $this->stubHttpRequest->method('getHeader')->with('Accept')
             ->willReturn('application/vnd.lizards-and-pumpkins.foo.v1+json');
         $this->stubHttpRequest->method('getPathWithoutWebsitePrefix')->willReturn('api');
@@ -72,6 +85,7 @@ class ApiRouterTest extends \PHPUnit_Framework_TestCase
             ->willReturn($stubApiRequestHandler);
 
         $this->stubHttpRequest->method('getPathWithoutWebsitePrefix')->willReturn('api/foo');
+        $this->stubHttpRequest->method('hasHeader')->with('Accept')->willReturn(true);
         $this->stubHttpRequest->method('getHeader')->with('Accept')
             ->willReturn('application/vnd.lizards-and-pumpkins.foo.v1+json');
         $result = $this->apiRouter->route($this->stubHttpRequest);
@@ -88,6 +102,7 @@ class ApiRouterTest extends \PHPUnit_Framework_TestCase
             ->method('getApiRequestHandler')
             ->willReturn($stubApiRequestHandler);
 
+        $this->stubHttpRequest->method('hasHeader')->with('Accept')->willReturn(true);
         $this->stubHttpRequest->method('getHeader')->with('Accept')
             ->willReturn('application/vnd.lizards-and-pumpkins.foo.v1+json');
         $this->stubHttpRequest->method('getPathWithoutWebsitePrefix')->willReturn('api/foo');


### PR DESCRIPTION
Closes #964.