### PR TITLE
Update integration tests to use consumer processAll() instead of process()

### DIFF
--- a/src/Logging/LoggingQueueDecorator.php
+++ b/src/Logging/LoggingQueueDecorator.php
@@ -45,8 +45,8 @@ class LoggingQueueDecorator implements Queue, Clearable
         }
     }
 
-    public function consume(MessageReceiver $messageReceiver, int $maxNumberOfMessagesToConsume)
+    public function consume(MessageReceiver $messageReceiver, int $numberOfMessagesToConsume)
     {
-        $this->decoratedQueue->consume($messageReceiver, $maxNumberOfMessagesToConsume);
+        $this->decoratedQueue->consume($messageReceiver, $numberOfMessagesToConsume);
     }
 }

--- a/src/Messaging/Queue.php
+++ b/src/Messaging/Queue.php
@@ -16,5 +16,5 @@ interface Queue extends \Countable
      */
     public function add(Message $message);
 
-    public function consume(MessageReceiver $messageReceiver, int $maxNumberOfMessagesToConsume);
+    public function consume(MessageReceiver $messageReceiver, int $numberOfMessagesToConsume);
 }

--- a/tests/Integration/Suites/ContentBlockImportTest.php
+++ b/tests/Integration/Suites/ContentBlockImportTest.php
@@ -56,8 +56,8 @@ class ContentBlockImportTest extends AbstractIntegrationTest
         $website = new InjectableDefaultWebFront($request, $this->factory, $implementationSpecificFactory);
         $website->processRequest();
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
     }
 
     private function getProductListingPageHtmlByUrlKey(string $urlKey) : string
@@ -96,8 +96,8 @@ class ContentBlockImportTest extends AbstractIntegrationTest
         $this->assertSame(202, $response->getStatusCode());
         $this->assertEquals(1, $domainCommandQueue->count());
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
 
         $logger = $this->factory->getLogger();
         $this->failIfMessagesWhereLogged($logger);

--- a/tests/Integration/Suites/EdgeToEdgeImportCatalogTest.php
+++ b/tests/Integration/Suites/EdgeToEdgeImportCatalogTest.php
@@ -48,8 +48,8 @@ class EdgeToEdgeImportCatalogTest extends AbstractIntegrationTest
         $website = new InjectableDefaultWebFront($request, $this->factory, $implementationSpecificFactory);
         $website->processRequest();
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
     }
 
     public function testCatalogImportDomainEventPutsProductToKeyValueStoreAndSearchIndex()

--- a/tests/Integration/Suites/ImageImportTest.php
+++ b/tests/Integration/Suites/ImageImportTest.php
@@ -53,7 +53,7 @@ class ImageImportTest extends AbstractIntegrationTest
             $queue->add(new ImageWasAddedDomainEvent($imageFilePath, $dataVersion));
         }
 
-        $factory->createDomainEventConsumer()->process();
+        $factory->createDomainEventConsumer()->processAll();
 
         $logger = $factory->getLogger();
         $this->failIfMessagesWhereLogged($logger);

--- a/tests/Integration/Suites/ProductDetailViewSnippetsTest.php
+++ b/tests/Integration/Suites/ProductDetailViewSnippetsTest.php
@@ -35,8 +35,8 @@ class ProductDetailViewSnippetsTest extends AbstractIntegrationTest
         $website = new InjectableDefaultWebFront($request, $this->factory, $implementationSpecificFactory);
         $website->processRequest();
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
     }
 
     private function getSkuOfFirstSimpleProductInFixture() : string

--- a/tests/Integration/Suites/ProductListingTestTrait.php
+++ b/tests/Integration/Suites/ProductListingTestTrait.php
@@ -72,8 +72,8 @@ trait ProductListingTestTrait
         $website = new InjectableDefaultWebFront($request, $this->factory, $implementationSpecificFactory);
         $website->processRequest();
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
     }
 
     private function prepareProductListingFixture()
@@ -91,8 +91,8 @@ trait ProductListingTestTrait
         $website = new InjectableDefaultWebFront($request, $this->factory, $implementationSpecificFactory);
         $website->processRequest();
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
     }
 
     private function registerProductListingSnippetKeyGenerator()

--- a/tests/Integration/Suites/ProductSearchEdgeToEdgeTest.php
+++ b/tests/Integration/Suites/ProductSearchEdgeToEdgeTest.php
@@ -35,8 +35,8 @@ class ProductSearchEdgeToEdgeTest extends AbstractIntegrationTest
         $website = new InjectableDefaultWebFront($request, $this->factory, $implementationSpecificFactory);
         $website->processRequest();
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
         
         $this->failIfMessagesWhereLogged($this->factory->getLogger());
     }

--- a/tests/Integration/Suites/ProductUrlKeyStoreTest.php
+++ b/tests/Integration/Suites/ProductUrlKeyStoreTest.php
@@ -33,8 +33,8 @@ class ProductUrlKeyStoreTest extends AbstractIntegrationTest
         $website = new InjectableDefaultWebFront($request, $this->factory, $implementationSpecificFactory);
         $website->processRequest();
 
-        $this->factory->createCommandConsumer()->process();
-        $this->factory->createDomainEventConsumer()->process();
+        $this->factory->createCommandConsumer()->processAll();
+        $this->factory->createDomainEventConsumer()->processAll();
     }
 
     public function testUrlKeysAreWrittenToStore()

--- a/tests/Integration/Util/AbstractIntegrationTest.php
+++ b/tests/Integration/Util/AbstractIntegrationTest.php
@@ -142,7 +142,7 @@ abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
     final protected function processQueueWhileMessagesPending(Queue $queue, QueueMessageConsumer $consumer)
     {
         while ($queue->count()) {
-            $consumer->process();
+            $consumer->processAll();
         }
     }
 }

--- a/tests/Integration/Util/Messaging/Queue/InMemoryQueue.php
+++ b/tests/Integration/Util/Messaging/Queue/InMemoryQueue.php
@@ -46,10 +46,13 @@ class InMemoryQueue implements Queue, Clearable
         $this->queue = [];
     }
 
-    public function consume(MessageReceiver $messageReceiver, int $numberOfMessagesBeforeReturn)
+    public function consume(MessageReceiver $messageReceiver, int $numberOfMessagesToConsumeBeforeReturn)
     {
-        while ($this->isReadyForNext() && $numberOfMessagesBeforeReturn-- > 0) {
-            $messageReceiver->receive($this->next());
+        while ($numberOfMessagesToConsumeBeforeReturn > 0) {
+            if ($this->isReadyForNext()) {
+                $messageReceiver->receive($this->next());
+                $numberOfMessagesToConsumeBeforeReturn--;
+            }
         }
     }
 }

--- a/tests/Unit/Suites/Logging/Stub/ClearableStubQueue.php
+++ b/tests/Unit/Suites/Logging/Stub/ClearableStubQueue.php
@@ -26,7 +26,7 @@ class ClearableStubQueue implements Queue, Clearable
         // Intentionally left empty
     }
 
-    public function consume(MessageReceiver $messageReceiver, int $maxNumberOfMessagesToConsume)
+    public function consume(MessageReceiver $messageReceiver, int $numberOfMessagesToConsume)
     {
         // Intentionally left empty
     }


### PR DESCRIPTION
The consumer method `processAll()` will not block, regardless of implementation, so the integration tests are more portable to use with different queue backends.