### PR TITLE
Issue #991: Use the specified data version when projection product listing templates

### DIFF
--- a/src/Context/ContextSource.php
+++ b/src/Context/ContextSource.php
@@ -100,7 +100,7 @@ abstract class ContextSource
      * @param DataVersion $version
      * @return Context[]
      */
-    public function getAllAvailableContextsWithVersion(DataVersion $version) : array
+    public function getAllAvailableContextsWithVersionApplied(DataVersion $version) : array
     {
         return $this->contextBuilder->createContextsFromDataSets(
             array_map(function (array $dataSet) use ($version) {

--- a/src/Import/CatalogImport.php
+++ b/src/Import/CatalogImport.php
@@ -125,7 +125,7 @@ class CatalogImport
     public function addProductsAndProductImagesToQueue(string $productXml)
     {
         $productBuilder = $this->productXmlToProductBuilder->createProductBuilderFromXml($productXml);
-        $contexts = $this->contextSource->getAllAvailableContextsWithVersion($this->dataVersion);
+        $contexts = $this->contextSource->getAllAvailableContextsWithVersionApplied($this->dataVersion);
         every($contexts, function (Context $context) use ($productBuilder, $productXml) {
             if ($productBuilder->isAvailableForContext($context)) {
                 $product = $productBuilder->getProductForContext($context);

--- a/src/Import/RootTemplate/Exception/InvalidTemplateIdException.php
+++ b/src/Import/RootTemplate/Exception/InvalidTemplateIdException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\Import\RootTemplate\Exception;
+
+class InvalidTemplateIdException extends \RuntimeException
+{
+
+}

--- a/src/Import/RootTemplate/Exception/NotUpdateTemplateCommandMessageException.php
+++ b/src/Import/RootTemplate/Exception/NotUpdateTemplateCommandMessageException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\Import\RootTemplate\Exception;
+
+class NotUpdateTemplateCommandMessageException extends \RuntimeException
+{
+
+}

--- a/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
+++ b/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
@@ -17,23 +17,16 @@ class TemplateWasUpdatedDomainEventHandler implements DomainEventHandler
     private $domainEvent;
 
     /**
-     * @var ContextSource
-     */
-    private $contextSource;
-
-    /**
      * @var TemplateProjectorLocator
      */
     private $projectorLocator;
 
     public function __construct(
         Message $message,
-        ContextSource $contextSource,
         TemplateProjectorLocator $projectorLocator
     ) {
         $this->domainEvent = TemplateWasUpdatedDomainEvent::fromMessage($message);
         $this->projectorLocator = $projectorLocator;
-        $this->contextSource = $contextSource;
     }
 
     public function process()

--- a/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
+++ b/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
@@ -8,6 +8,7 @@ use LizardsAndPumpkins\Context\ContextSource;
 use LizardsAndPumpkins\Import\RootTemplate\Import\TemplateProjectorLocator;
 use LizardsAndPumpkins\Messaging\Event\DomainEventHandler;
 use LizardsAndPumpkins\Messaging\Queue\Message;
+use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 class TemplateWasUpdatedDomainEventHandler implements DomainEventHandler
 {
@@ -32,6 +33,6 @@ class TemplateWasUpdatedDomainEventHandler implements DomainEventHandler
     public function process()
     {
         $projector = $this->projectorLocator->getTemplateProjectorForCode($this->domainEvent->getTemplateId());
-        $projector->project($this->domainEvent->getTemplateContent());
+        $projector->project(TemplateProjectionData::fromEvent($this->domainEvent));
     }
 }

--- a/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
+++ b/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\Import\RootTemplate;
 
-use LizardsAndPumpkins\Context\ContextSource;
 use LizardsAndPumpkins\Import\RootTemplate\Import\TemplateProjectorLocator;
 use LizardsAndPumpkins\Messaging\Event\DomainEventHandler;
 use LizardsAndPumpkins\Messaging\Queue\Message;

--- a/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
+++ b/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace LizardsAndPumpkins\Import\RootTemplate;
 
@@ -21,10 +21,8 @@ class TemplateWasUpdatedDomainEventHandler implements DomainEventHandler
      */
     private $projectorLocator;
 
-    public function __construct(
-        Message $message,
-        TemplateProjectorLocator $projectorLocator
-    ) {
+    public function __construct(Message $message, TemplateProjectorLocator $projectorLocator)
+    {
         $this->domainEvent = TemplateWasUpdatedDomainEvent::fromMessage($message);
         $this->projectorLocator = $projectorLocator;
     }

--- a/src/Import/RootTemplate/UpdateTemplateCommand.php
+++ b/src/Import/RootTemplate/UpdateTemplateCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\Import\RootTemplate;
+
+use LizardsAndPumpkins\Context\DataVersion\DataVersion;
+use LizardsAndPumpkins\Import\RootTemplate\Exception\InvalidTemplateIdException;
+use LizardsAndPumpkins\Import\RootTemplate\Exception\NotUpdateTemplateCommandMessageException;
+use LizardsAndPumpkins\Messaging\Command\Command;
+use LizardsAndPumpkins\Messaging\Queue\Message;
+
+class UpdateTemplateCommand implements Command
+{
+    const CODE = 'update_template';
+    
+    /**
+     * @var string
+     */
+    private $templateId;
+
+    /**
+     * @var string
+     */
+    private $templateContent;
+
+    /**
+     * @var DataVersion
+     */
+    private $dataVersion;
+
+    public function __construct(string $templateId, string $templateContent, DataVersion $dataVersion)
+    {
+        $this->validateTemplateId($templateId);
+        $this->templateId = $templateId;
+        $this->templateContent = $templateContent;
+        $this->dataVersion = $dataVersion;
+    }
+
+    public function toMessage(): Message
+    {
+        $name = self::CODE;
+        $payload = ['template_id' => $this->templateId, 'template_content' => $this->templateContent];
+        $metadata = ['data_version' => (string) $this->dataVersion];
+
+        return Message::withCurrentTime($name, $payload, $metadata);
+    }
+
+    public static function fromMessage(Message $message)
+    {
+        if ($message->getName() !== self::CODE) {
+            throw new NotUpdateTemplateCommandMessageException(
+                sprintf('Invalid message code "%s", expected %s', $message->getName(), UpdateTemplateCommand::CODE)
+            );
+        }
+        
+        return new self(
+            $message->getPayload()['template_id'],
+            $message->getPayload()['template_content'],
+            DataVersion::fromVersionString($message->getMetadata()['data_version'])
+        );
+    }
+
+    public function getTemplateId(): string
+    {
+        return $this->templateId;
+    }
+
+    public function getTemplateContent(): string
+    {
+        return $this->templateContent;
+    }
+
+    public function getDataVersion(): DataVersion
+    {
+        return $this->dataVersion;
+    }
+
+    private function validateTemplateId(string $templateId)
+    {
+        if ('' === $templateId) {
+            throw new InvalidTemplateIdException('Invalid template ID: empty string');
+        }
+        if (preg_match('/[ \'""]/', $templateId)) {
+            throw new InvalidTemplateIdException('Invalid template ID: no spaces or quotes allowed');
+        }
+    }
+}

--- a/src/Import/RootTemplate/UpdateTemplateCommand.php
+++ b/src/Import/RootTemplate/UpdateTemplateCommand.php
@@ -81,7 +81,7 @@ class UpdateTemplateCommand implements Command
         if ('' === $templateId) {
             throw new InvalidTemplateIdException('Invalid template ID: empty string');
         }
-        if (preg_match('/[ \'""]/', $templateId)) {
+        if (preg_match('/[ \'"\n\r]/', $templateId)) {
             throw new InvalidTemplateIdException('Invalid template ID: no spaces or quotes allowed');
         }
     }

--- a/src/Import/RootTemplate/UpdateTemplateCommandHandler.php
+++ b/src/Import/RootTemplate/UpdateTemplateCommandHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\Import\RootTemplate;
+
+use LizardsAndPumpkins\Messaging\Command\CommandHandler;
+use LizardsAndPumpkins\Messaging\Event\DomainEventQueue;
+use LizardsAndPumpkins\Messaging\Queue\Message;
+
+class UpdateTemplateCommandHandler implements CommandHandler
+{
+    /**
+     * @var UpdateTemplateCommand
+     */
+    private $command;
+
+    /**
+     * @var DomainEventQueue
+     */
+    private $domainEventQueue;
+
+    public function __construct(Message $message, DomainEventQueue $domainEventQueue)
+    {
+        $this->command = UpdateTemplateCommand::fromMessage($message);
+        $this->domainEventQueue = $domainEventQueue;
+    }
+
+    public function process()
+    {
+        $templateId = $this->command->getTemplateId();
+        $templateContent = $this->command->getTemplateContent();
+        $this->domainEventQueue->add(new TemplateWasUpdatedDomainEvent($templateId, $templateContent));
+    }
+}

--- a/src/Import/RootTemplate/UpdateTemplateCommandHandler.php
+++ b/src/Import/RootTemplate/UpdateTemplateCommandHandler.php
@@ -30,6 +30,7 @@ class UpdateTemplateCommandHandler implements CommandHandler
     {
         $templateId = $this->command->getTemplateId();
         $templateContent = $this->command->getTemplateContent();
-        $this->domainEventQueue->add(new TemplateWasUpdatedDomainEvent($templateId, $templateContent));
+        $dataVersion = $this->command->getDataVersion();
+        $this->domainEventQueue->add(new TemplateWasUpdatedDomainEvent($templateId, $templateContent, $dataVersion));
     }
 }

--- a/src/Logging/LoggingCommandHandlerFactory.php
+++ b/src/Logging/LoggingCommandHandlerFactory.php
@@ -84,4 +84,12 @@ class LoggingCommandHandlerFactory implements CommandHandlerFactory, Factory
             $commandFactoryDelegate->createSetCurrentDataVersionCommandHandler($message)
         );
     }
+
+    public function createUpdateTemplateCommandHandler(Message $message): CommandHandler
+    {
+        $commandFactoryDelegate = $this->getCommandFactoryDelegate();
+        return $commandFactoryDelegate->createProcessTimeLoggingCommandHandlerDecorator(
+            $commandFactoryDelegate->createUpdateTemplateCommandHandler($message)
+        );
+    }
 }

--- a/src/Messaging/Command/CommandHandlerFactory.php
+++ b/src/Messaging/Command/CommandHandlerFactory.php
@@ -21,4 +21,6 @@ interface CommandHandlerFactory
     public function createImportCatalogCommandHandler(Message $message): CommandHandler;
     
     public function createSetCurrentDataVersionCommandHandler(Message $message): CommandHandler;
+    
+    public function createUpdateTemplateCommandHandler(Message $message): CommandHandler;
 }

--- a/src/ProductListing/Import/ProductListingTemplateProjector.php
+++ b/src/ProductListing/Import/ProductListingTemplateProjector.php
@@ -29,11 +29,10 @@ class ProductListingTemplateProjector implements Projector
     }
 
     /**
-     * @param mixed $productsPerPageSourceData
+     * @param mixed $projectionData
      */
-    public function project($productsPerPageSourceData)
+    public function project($projectionData)
     {
-        $projectionData = [];
         $snippets = $this->snippetRendererCollection->render($projectionData);
         $this->dataPoolWriter->writeSnippets(...$snippets);
     }

--- a/src/ProductListing/Import/ProductListingTemplateSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductListingTemplateSnippetRenderer.php
@@ -54,7 +54,7 @@ class ProductListingTemplateSnippetRenderer implements SnippetRenderer
     {
         return array_map(function (Context $context) use ($dataToRender) {
             return $this->renderProductListingPageSnippetForContext($dataToRender, $context);
-        }, $this->contextSource->getAllAvailableContextsWithVersion($dataToRender->getDataVersion()));
+        }, $this->contextSource->getAllAvailableContextsWithVersionApplied($dataToRender->getDataVersion()));
     }
 
     private function renderProductListingPageSnippetForContext(

--- a/src/ProductListing/Import/ProductListingTemplateSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductListingTemplateSnippetRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace LizardsAndPumpkins\ProductListing\Import;
 
@@ -10,6 +10,7 @@ use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\ProductListingBlo
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\Import\SnippetRenderer;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
+use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 class ProductListingTemplateSnippetRenderer implements SnippetRenderer
 {
@@ -41,26 +42,26 @@ class ProductListingTemplateSnippetRenderer implements SnippetRenderer
     }
 
     /**
-     * @param mixed $dataObject
+     * @param TemplateProjectionData $dataToRender
      * @return Snippet[]
      */
-    public function render($dataObject) : array
+    public function render($dataToRender): array
     {
-        // todo: important! Use data version from $dataObject
-        return array_map(function (Context $context) use ($dataObject) {
-            return $this->renderProductListingPageSnippetForContext($dataObject, $context);
-        }, $this->contextSource->getAllAvailableContexts());
-
+        return $this->projectDataForAllContexts($dataToRender);
     }
 
-    /**
-     * @param mixed $dataObject
-     * @param Context $context
-     * @return Snippet
-     */
-    private function renderProductListingPageSnippetForContext($dataObject, Context $context) : Snippet
+    private function projectDataForAllContexts(TemplateProjectionData $dataToRender): array
     {
-        $content = $this->blockRenderer->render($dataObject, $context);
+        return array_map(function (Context $context) use ($dataToRender) {
+            return $this->renderProductListingPageSnippetForContext($dataToRender, $context);
+        }, $this->contextSource->getAllAvailableContextsWithVersion($dataToRender->getDataVersion()));
+    }
+
+    private function renderProductListingPageSnippetForContext(
+        TemplateProjectionData $dataToRender,
+        Context $context
+    ): Snippet {
+        $content = $this->blockRenderer->render($dataToRender, $context);
         $key = $this->snippetKeyGenerator->getKeyForContext($context, []);
 
         return Snippet::create($key, $content);

--- a/src/ProductListing/Import/TemplateRendering/TemplateProjectionData.php
+++ b/src/ProductListing/Import/TemplateRendering/TemplateProjectionData.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\ProductListing\Import\TemplateRendering;
+
+use LizardsAndPumpkins\Context\DataVersion\DataVersion;
+
+class TemplateProjectionData
+{
+    /**
+     * @var string
+     */
+    private $content;
+
+    /**
+     * @var DataVersion
+     */
+    private $dataVersion;
+
+    public function __construct(string $content, DataVersion $dataVersion)
+    {
+        $this->content = $content;
+        $this->dataVersion = $dataVersion;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function getDataVersion(): DataVersion
+    {
+        return $this->dataVersion;
+    }
+}

--- a/src/ProductListing/Import/TemplateRendering/TemplateProjectionData.php
+++ b/src/ProductListing/Import/TemplateRendering/TemplateProjectionData.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace LizardsAndPumpkins\ProductListing\Import\TemplateRendering;
 
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
+use LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent;
+use LizardsAndPumpkins\Messaging\Event\DomainEvent;
 
 class TemplateProjectionData
 {
@@ -32,5 +34,10 @@ class TemplateProjectionData
     public function getDataVersion(): DataVersion
     {
         return $this->dataVersion;
+    }
+
+    public static function fromEvent(TemplateWasUpdatedDomainEvent $event): self
+    {
+        return new self($event->getTemplateContent(), $event->getDataVersion());
     }
 }

--- a/src/RestApi/RestApiFactory.php
+++ b/src/RestApi/RestApiFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\RestApi;
 
+use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\DataPool\DataVersion\RestApi\CurrentVersionApiV1GetRequestHandler;
 use LizardsAndPumpkins\DataPool\DataVersion\RestApi\CurrentVersionApiV1PutRequestHandler;
 use LizardsAndPumpkins\Import\ContentBlock\RestApi\ContentBlocksApiV1PutRequestHandler;
@@ -56,7 +57,8 @@ class RestApiFactory implements Factory
     public function createTemplatesApiV1PutRequestHandler(): TemplatesApiV1PutRequestHandler
     {
         return new TemplatesApiV1PutRequestHandler(
-            $this->getMasterFactory()->getEventQueue()
+            $this->getMasterFactory()->getCommandQueue(),
+            DataVersion::fromVersionString($this->getMasterFactory()->getCurrentDataVersion())
         );
     }
 

--- a/src/Util/Factory/CommonFactory.php
+++ b/src/Util/Factory/CommonFactory.php
@@ -741,7 +741,7 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
         return $this->countryContextPartBuilder;
     }
 
-    private function getCurrentDataVersion() : string
+    public function getCurrentDataVersion() : string
     {
         if (null === $this->currentDataVersion) {
             /** @var DataPoolReader $dataPoolReader */

--- a/src/Util/Factory/CommonFactory.php
+++ b/src/Util/Factory/CommonFactory.php
@@ -36,6 +36,7 @@ use LizardsAndPumpkins\DataPool\UrlKeyStore\UrlKeyStore;
 use LizardsAndPumpkins\Import\ImportCatalogCommandHandler;
 use LizardsAndPumpkins\Import\PageMetaInfoSnippetContent;
 use LizardsAndPumpkins\Import\Product\AttributeCode;
+use LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommandHandler;
 use LizardsAndPumpkins\Import\SnippetRenderer;
 use LizardsAndPumpkins\Import\SnippetRendererCollection;
 use LizardsAndPumpkins\Messaging\Command\CommandConsumer;
@@ -920,10 +921,12 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
 
     public function createUpdateContentBlockCommandHandler(Message $message) : CommandHandler
     {
-        return new UpdateContentBlockCommandHandler(
-            $message,
-            $this->getMasterFactory()->getEventQueue()
-        );
+        return new UpdateContentBlockCommandHandler($message, $this->getMasterFactory()->getEventQueue());
+    }
+
+    public function createUpdateTemplateCommandHandler(Message $message): CommandHandler
+    {
+        return new UpdateTemplateCommandHandler($message, $this->getMasterFactory()->getEventQueue());
     }
 
     public function createContentBlockWasUpdatedDomainEventHandler(Message $event) : DomainEventHandler

--- a/src/Util/Factory/CommonFactory.php
+++ b/src/Util/Factory/CommonFactory.php
@@ -220,7 +220,6 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
     {
         return new TemplateWasUpdatedDomainEventHandler(
             $event,
-            $this->getMasterFactory()->getContextSource(),
             $this->getMasterFactory()->createTemplateProjectorLocator()
         );
     }

--- a/tests/Unit/Suites/Context/ContextSourceTest.php
+++ b/tests/Unit/Suites/Context/ContextSourceTest.php
@@ -107,6 +107,6 @@ class ContextSourceTest extends \PHPUnit_Framework_TestCase
                 }, $dataSets);
                 return [];
             });
-        $this->contextSource->getAllAvailableContextsWithVersion($testVersion);
+        $this->contextSource->getAllAvailableContextsWithVersionApplied($testVersion);
     }
 }

--- a/tests/Unit/Suites/Import/CatalogImportTest.php
+++ b/tests/Unit/Suites/Import/CatalogImportTest.php
@@ -134,7 +134,7 @@ class CatalogImportTest extends \PHPUnit_Framework_TestCase
         $this->stubProductListingBuilder = $this->createMockProductsPerPageForContextBuilder();
         $this->mockEventQueue = $this->createMock(DomainEventQueue::class);
         $this->contextSource = $this->createMock(ContextSource::class);
-        $this->contextSource->method('getAllAvailableContextsWithVersion')->willReturn(
+        $this->contextSource->method('getAllAvailableContextsWithVersionApplied')->willReturn(
             [$this->createMock(Context::class)]
         );
         $this->mockLogger = $this->createMock(Logger::class);

--- a/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\Import\RootTemplate;
 
-use LizardsAndPumpkins\Context\ContextSource;
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Import\Projector;
 use LizardsAndPumpkins\Import\RootTemplate\Import\TemplateProjectorLocator;
@@ -40,17 +39,8 @@ class TemplateWasUpdatedDomainEventHandlerTest extends \PHPUnit_Framework_TestCa
 
         return new TemplateWasUpdatedDomainEventHandler(
             $message,
-            $this->createStubContextSource(),
             $stubTemplateProjectorLocator
         );
-    }
-
-    /**
-     * @return ContextSource|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private function createStubContextSource() : ContextSource
-    {
-        return $this->createMock(ContextSource::class);
     }
 
     protected function setUp()

--- a/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LizardsAndPumpkins\Import\RootTemplate;
 
 use LizardsAndPumpkins\Context\ContextSource;
+use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Import\Projector;
 use LizardsAndPumpkins\Import\RootTemplate\Import\TemplateProjectorLocator;
 use LizardsAndPumpkins\Messaging\Event\DomainEventHandler;
@@ -17,6 +18,7 @@ use LizardsAndPumpkins\Messaging\Queue\Message;
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageMetadata
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageName
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessagePayload
+ * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
  */
 class TemplateWasUpdatedDomainEventHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -53,7 +55,8 @@ class TemplateWasUpdatedDomainEventHandlerTest extends \PHPUnit_Framework_TestCa
 
     protected function setUp()
     {
-        $testEvent = new TemplateWasUpdatedDomainEvent('foo template id', 'bar template content');
+        $dummyDataVersion = DataVersion::fromVersionString('foo');
+        $testEvent = new TemplateWasUpdatedDomainEvent('foo template id', 'bar template content', $dummyDataVersion);
 
         $this->mockProjector = $this->createMock(Projector::class);
 

--- a/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
@@ -39,10 +39,7 @@ class TemplateWasUpdatedDomainEventHandlerTest extends \PHPUnit_Framework_TestCa
         $stubTemplateProjectorLocator = $this->createMock(TemplateProjectorLocator::class);
         $stubTemplateProjectorLocator->method('getTemplateProjectorForCode')->willReturn($this->mockProjector);
 
-        return new TemplateWasUpdatedDomainEventHandler(
-            $message,
-            $stubTemplateProjectorLocator
-        );
+        return new TemplateWasUpdatedDomainEventHandler($message, $stubTemplateProjectorLocator);
     }
 
     protected function setUp()

--- a/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
@@ -9,6 +9,7 @@ use LizardsAndPumpkins\Import\Projector;
 use LizardsAndPumpkins\Import\RootTemplate\Import\TemplateProjectorLocator;
 use LizardsAndPumpkins\Messaging\Event\DomainEventHandler;
 use LizardsAndPumpkins\Messaging\Queue\Message;
+use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 /**
  * @covers \LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEventHandler
@@ -18,6 +19,7 @@ use LizardsAndPumpkins\Messaging\Queue\Message;
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageName
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessagePayload
  * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
+ * @uses   \LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData
  */
 class TemplateWasUpdatedDomainEventHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -60,7 +62,8 @@ class TemplateWasUpdatedDomainEventHandlerTest extends \PHPUnit_Framework_TestCa
 
     public function testProjectionIsTriggered()
     {
-        $this->mockProjector->expects($this->once())->method('project');
+        $this->mockProjector->expects($this->once())->method('project')
+            ->with($this->isInstanceOf(TemplateProjectionData::class));
         $this->domainEventHandler->process();
     }
 }

--- a/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandHandlerTest.php
@@ -56,7 +56,7 @@ class UpdateTemplateCommandHandlerTest extends TestCase
             ->willReturnCallback(function(TemplateWasUpdatedDomainEvent $event) {
                 $this->assertSame($this->testTemplateId, $event->getTemplateId());
                 $this->assertSame($this->testContent, $event->getTemplateContent());
-                // TODO: check for data version once it's implemented!
+                $this->assertSame((string) $this->testDataVersion, (string) $event->getDataVersion());
             });
         $this->createCommandHandler()->process();
     }

--- a/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandHandlerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\Import\RootTemplate;
+
+use LizardsAndPumpkins\Context\DataVersion\DataVersion;
+use LizardsAndPumpkins\Messaging\Command\CommandHandler;
+use LizardsAndPumpkins\Messaging\Event\DomainEventQueue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommandHandler
+ * @uses   \LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommand
+ * @uses   \LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent
+ * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\Message
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageName
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\MessagePayload
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageMetadata
+ */
+class UpdateTemplateCommandHandlerTest extends TestCase
+{
+    private $testTemplateId = 'test';
+
+    private $testContent = 'test';
+
+    private $testDataVersion;
+
+    /**
+     * @var DomainEventQueue|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockEventQueue;
+
+    protected function setUp()
+    {
+        $this->mockEventQueue = $this->createMock(DomainEventQueue::class);
+        $this->testDataVersion = DataVersion::fromVersionString('test');
+    }
+
+    private function createCommandHandler(): UpdateTemplateCommandHandler
+    {
+        $command = new UpdateTemplateCommand($this->testTemplateId, $this->testContent, $this->testDataVersion);
+        $message = $command->toMessage();
+        return new UpdateTemplateCommandHandler($message, $this->mockEventQueue);
+    }
+
+    public function testIsACommandHandler()
+    {
+        $this->assertInstanceOf(CommandHandler::class, $this->createCommandHandler());
+    }
+
+    public function testEmitsATemplateWasUpdatedEvent()
+    {
+        $this->mockEventQueue->expects($this->once())->method('add')
+            ->willReturnCallback(function(TemplateWasUpdatedDomainEvent $event) {
+                $this->assertSame($this->testTemplateId, $event->getTemplateId());
+                $this->assertSame($this->testContent, $event->getTemplateContent());
+                // TODO: check for data version once it's implemented!
+            });
+        $this->createCommandHandler()->process();
+    }
+}

--- a/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandHandlerTest.php
@@ -25,6 +25,9 @@ class UpdateTemplateCommandHandlerTest extends TestCase
 
     private $testContent = 'test';
 
+    /**
+     * @var DataVersion
+     */
     private $testDataVersion;
 
     /**

--- a/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandTest.php
@@ -42,7 +42,7 @@ class UpdateTemplateCommandTest extends TestCase
     }
 
     /**
-     * @dataProvider InvalidTemplateIdProvider
+     * @dataProvider invalidTemplateIdProvider
      */
     public function testThrowsExceptionIfTheTemplateIdIsInvalid(string $invalidTemplateId)
     {
@@ -51,7 +51,7 @@ class UpdateTemplateCommandTest extends TestCase
         new UpdateTemplateCommand($invalidTemplateId, 'example content', $this->testDataVersion);
     }
 
-    public function InvalidTemplateIdProvider(): array
+    public function invalidTemplateIdProvider(): array
     {
         return [
             'empty'               => [''],

--- a/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\Import\RootTemplate;
+
+use LizardsAndPumpkins\Context\DataVersion\DataVersion;
+use LizardsAndPumpkins\Import\RootTemplate\Exception\InvalidTemplateIdException;
+use LizardsAndPumpkins\Import\RootTemplate\Exception\NotUpdateTemplateCommandMessageException;
+use LizardsAndPumpkins\Messaging\Command\Command;
+use LizardsAndPumpkins\Messaging\Queue\Message;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommand
+ * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\Message
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageName
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\MessagePayload
+ * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageMetadata
+ */
+class UpdateTemplateCommandTest extends TestCase
+{
+    /**
+     * @var DataVersion
+     */
+    private $testDataVersion;
+
+    private function createCommand($templateId, $templateContent): UpdateTemplateCommand
+    {
+        return new UpdateTemplateCommand($templateId, $templateContent, $this->testDataVersion);
+    }
+
+    protected function setUp()
+    {
+        $this->testDataVersion = DataVersion::fromVersionString('xyz');
+    }
+
+    public function testIsCommand()
+    {
+        $this->assertInstanceOf(Command::class, $this->createCommand('test_id', '...'));
+    }
+
+    /**
+     * @dataProvider InvalidTemplateIdProvider
+     */
+    public function testThrowsExceptionIfTheTemplateIdIsInvalid(string $invalidTemplateId)
+    {
+        $this->expectException(InvalidTemplateIdException::class);
+        $this->expectExceptionMessage('Invalid template ID: ');
+        new UpdateTemplateCommand($invalidTemplateId, 'example content', $this->testDataVersion);
+    }
+
+    public function InvalidTemplateIdProvider(): array
+    {
+        return [
+            'empty'               => [''],
+            'leading space'       => [' xxx'],
+            'trailig space'       => ['xxx '],
+            'space in the middle' => ['x x'],
+            'only space'          => [' '],
+            'single quote'        => ["xx'xx'"],
+            'double quote'        => ['yy"yy'],
+        ];
+    }
+
+    public function testReturnsTheGivenTemplateId()
+    {
+        $this->assertSame('bar', $this->createCommand('bar', 'example content')->getTemplateId());
+    }
+
+    public function testReturnsTheTemplateContent()
+    {
+        $this->assertSame('example content', $this->createCommand('foo', 'example content')->getTemplateContent());
+    }
+
+    public function testReturnsTheDataVersion()
+    {
+        $this->assertSame($this->testDataVersion, $this->createCommand('example_id', 'example')->getDataVersion());
+    }
+
+    public function testCanBeConvertedIntoAMessageInstance()
+    {
+        $updateTemplateCommand = $this->createCommand('foo', 'bar');
+        $message = $updateTemplateCommand->toMessage();
+        
+        $this->assertInstanceOf(Message::class, $message);
+        $this->assertSame(UpdateTemplateCommand::CODE, $message->getName());
+        $this->assertSame($updateTemplateCommand->getTemplateId(), $message->getPayload()['template_id']);
+        $this->assertSame($updateTemplateCommand->getTemplateContent(), $message->getPayload()['template_content']);
+        $this->assertEquals((string) $this->testDataVersion, $message->getMetadata()['data_version']);
+    }
+
+    public function testThrowsExceptionIfTheMessageNameDoesNotMatchTheCommandCode()
+    {
+        $this->expectException(NotUpdateTemplateCommandMessageException::class);
+        $this->expectExceptionMessage('Invalid message code "foo", expected ' . UpdateTemplateCommand::CODE);
+        
+        UpdateTemplateCommand::fromMessage(Message::withCurrentTime('foo', [], []));
+    }
+
+    public function testCanBeRehydratedFromMessage()
+    {
+        $sourceCommand = $this->createCommand('foo', 'bar');
+        $rehydratedCommand = UpdateTemplateCommand::fromMessage($sourceCommand->toMessage());
+        
+        $this->assertInstanceOf(UpdateTemplateCommand::class, $rehydratedCommand);
+        $this->assertSame($sourceCommand->getTemplateId(), $rehydratedCommand->getTemplateId());
+        $this->assertSame($sourceCommand->getTemplateContent(), $rehydratedCommand->getTemplateContent());
+        $this->assertEquals((string) $sourceCommand->getDataVersion(), $rehydratedCommand->getDataVersion());
+    }
+}

--- a/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/UpdateTemplateCommandTest.php
@@ -61,6 +61,8 @@ class UpdateTemplateCommandTest extends TestCase
             'only space'          => [' '],
             'single quote'        => ["xx'xx'"],
             'double quote'        => ['yy"yy'],
+            'newline'             => ["xx\n"],
+            'carriage return'     => ["xx\r"],
         ];
     }
 
@@ -83,7 +85,7 @@ class UpdateTemplateCommandTest extends TestCase
     {
         $updateTemplateCommand = $this->createCommand('foo', 'bar');
         $message = $updateTemplateCommand->toMessage();
-        
+
         $this->assertInstanceOf(Message::class, $message);
         $this->assertSame(UpdateTemplateCommand::CODE, $message->getName());
         $this->assertSame($updateTemplateCommand->getTemplateId(), $message->getPayload()['template_id']);
@@ -95,7 +97,7 @@ class UpdateTemplateCommandTest extends TestCase
     {
         $this->expectException(NotUpdateTemplateCommandMessageException::class);
         $this->expectExceptionMessage('Invalid message code "foo", expected ' . UpdateTemplateCommand::CODE);
-        
+
         UpdateTemplateCommand::fromMessage(Message::withCurrentTime('foo', [], []));
     }
 
@@ -103,7 +105,7 @@ class UpdateTemplateCommandTest extends TestCase
     {
         $sourceCommand = $this->createCommand('foo', 'bar');
         $rehydratedCommand = UpdateTemplateCommand::fromMessage($sourceCommand->toMessage());
-        
+
         $this->assertInstanceOf(UpdateTemplateCommand::class, $rehydratedCommand);
         $this->assertSame($sourceCommand->getTemplateId(), $rehydratedCommand->getTemplateId());
         $this->assertSame($sourceCommand->getTemplateContent(), $rehydratedCommand->getTemplateContent());

--- a/tests/Unit/Suites/Logging/LoggingCommandHandlerFactoryTest.php
+++ b/tests/Unit/Suites/Logging/LoggingCommandHandlerFactoryTest.php
@@ -17,6 +17,7 @@ use LizardsAndPumpkins\Import\Product\ProductAttributeList;
 use LizardsAndPumpkins\Import\Product\ProductId;
 use LizardsAndPumpkins\Import\Product\SimpleProduct;
 use LizardsAndPumpkins\Import\Product\UpdateProductCommand;
+use LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommand;
 use LizardsAndPumpkins\Import\Tax\ProductTaxClass;
 use LizardsAndPumpkins\Messaging\Command\CommandHandlerFactory;
 use LizardsAndPumpkins\Messaging\Consumer\ShutdownWorkerDirective;
@@ -66,6 +67,8 @@ use LizardsAndPumpkins\UnitTestFactory;
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\SetCurrentDataVersionCommandHandler
  * @uses   \LizardsAndPumpkins\DataPool\DataPoolReader
  * @uses   \LizardsAndPumpkins\DataPool\DataPoolWriter
+ * @uses   \LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommandHandler
+ * @uses   \LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommand
  */
 class LoggingCommandHandlerFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -151,6 +154,13 @@ class LoggingCommandHandlerFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $message = (new SetCurrentDataVersionCommand(DataVersion::fromVersionString('qux')))->toMessage();
         $commandHandler = $this->loggingCommandHandlerFactory->createSetCurrentDataVersionCommandHandler($message);
+        $this->assertInstanceOf(ProcessTimeLoggingCommandHandlerDecorator::class, $commandHandler);
+    }
+
+    public function testReturnsADecoratedUpdateTemplateCommandHandler()
+    {
+        $message = (new UpdateTemplateCommand('foo', 'bar', DataVersion::fromVersionString('baz')))->toMessage();
+        $commandHandler = $this->loggingCommandHandlerFactory->createUpdateTemplateCommandHandler($message);
         $this->assertInstanceOf(ProcessTimeLoggingCommandHandlerDecorator::class, $commandHandler);
     }
 }

--- a/tests/Unit/Suites/Logging/LoggingDomainEventHandlerFactoryTest.php
+++ b/tests/Unit/Suites/Logging/LoggingDomainEventHandlerFactoryTest.php
@@ -175,7 +175,7 @@ class LoggingDomainEventHandlerFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testItReturnsADecoratedTemplateWasUpdatedDomainEventHandler()
     {
-        $testEvent = new TemplateWasUpdatedDomainEvent('foo', 'bar');
+        $testEvent = new TemplateWasUpdatedDomainEvent('foo', 'bar', DataVersion::fromVersionString('baz'));
         $result = $this->factory->createTemplateWasUpdatedDomainEventHandler($testEvent->toMessage());
         $this->assertDecoratedDomainEventHandlerInstanceOf(TemplateWasUpdatedDomainEventHandler::class, $result);
     }

--- a/tests/Unit/Suites/Messaging/Command/CommandHandlerLocatorTest.php
+++ b/tests/Unit/Suites/Messaging/Command/CommandHandlerLocatorTest.php
@@ -8,6 +8,8 @@ use LizardsAndPumpkins\Import\ContentBlock\UpdateContentBlockCommand;
 use LizardsAndPumpkins\Import\ContentBlock\UpdateContentBlockCommandHandler;
 use LizardsAndPumpkins\Import\ImportCatalogCommand;
 use LizardsAndPumpkins\Import\ImportCatalogCommandHandler;
+use LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommand;
+use LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommandHandler;
 use LizardsAndPumpkins\Messaging\Command\Exception\UnableToFindCommandHandlerException;
 use LizardsAndPumpkins\Messaging\Queue\Message;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
@@ -81,5 +83,22 @@ class CommandHandlerLocatorTest extends \PHPUnit_Framework_TestCase
         $result = $this->locator->getHandlerFor($stubCommand);
 
         $this->assertInstanceOf(ImportCatalogCommandHandler::class, $result);
+    }
+
+    public function testReturnsUpdateTemplateCommandHandler()
+    {
+        $stubHandler = $this->createMock(UpdateTemplateCommandHandler::class);
+
+        $this->factory->expects($this->once())
+            ->method('createUpdateTemplateCommandHandler')
+            ->willReturn($stubHandler);
+
+        /** @var Message|\PHPUnit_Framework_MockObject_MockObject $stubCommand */
+        $stubCommand = $this->createMock(Message::class);
+        $stubCommand->method('getName')->willReturn(UpdateTemplateCommand::CODE);
+
+        $result = $this->locator->getHandlerFor($stubCommand);
+
+        $this->assertInstanceOf(UpdateTemplateCommandHandler::class, $result);
     }
 }

--- a/tests/Unit/Suites/ProductListing/Import/ProductListingTemplateSnippetRendererTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/ProductListingTemplateSnippetRendererTest.php
@@ -10,6 +10,7 @@ use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\ProductListingBlo
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\Import\SnippetRenderer;
+use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 /**
  * @covers \LizardsAndPumpkins\ProductListing\Import\ProductListingTemplateSnippetRenderer
@@ -54,7 +55,8 @@ class ProductListingTemplateSnippetRendererTest extends \PHPUnit_Framework_TestC
 
     public function testArrayOfSnippetsIsReturned()
     {
-        $dataObject = new \stdClass();
+        /** @var TemplateProjectionData|\PHPUnit_Framework_MockObject_MockObject $dataObject */
+        $dataObject = $this->createMock(TemplateProjectionData::class);
         $result = $this->renderer->render($dataObject);
 
         $this->assertContainsOnly(Snippet::class, $result);

--- a/tests/Unit/Suites/ProductListing/Import/TemplateRendering/TemplateProjectionDataTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/TemplateRendering/TemplateProjectionDataTest.php
@@ -5,11 +5,13 @@ declare(strict_types = 1);
 namespace LizardsAndPumpkins\ProductListing\Import\TemplateRendering;
 
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
+use LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData
  * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
+ * @uses   \LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent
  */
 class TemplateProjectionDataTest extends TestCase
 {
@@ -26,5 +28,18 @@ class TemplateProjectionDataTest extends TestCase
         $dataVersion = DataVersion::fromVersionString('bar');
         $templateProjectionData = new TemplateProjectionData($testContent, $dataVersion);
         $this->assertEquals((string) $dataVersion, $templateProjectionData->getDataVersion());
+    }
+
+    public function testCanBeCreatedFromTemplateWasUpdatedDomanEvent()
+    {
+        $event = new TemplateWasUpdatedDomainEvent(
+            $templateId = 'foo',
+            $templateContent = 'bar',
+            $dataVersion = DataVersion::fromVersionString('baz')
+        );
+        $projectionData = TemplateProjectionData::fromEvent($event);
+        $this->assertInstanceOf(TemplateProjectionData::class, $projectionData);
+        $this->assertSame($event->getTemplateContent(), $projectionData->getContent());
+        $this->assertSame($event->getDataVersion(), $projectionData->getDataVersion());
     }
 }

--- a/tests/Unit/Suites/ProductListing/Import/TemplateRendering/TemplateProjectionDataTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/TemplateRendering/TemplateProjectionDataTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LizardsAndPumpkins\ProductListing\Import\TemplateRendering;
+
+use LizardsAndPumpkins\Context\DataVersion\DataVersion;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData
+ * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
+ */
+class TemplateProjectionDataTest extends TestCase
+{
+    public function testReturnsTheInjectedTemplateContent()
+    {
+        $testContent = 'foo';
+        $dataVersion = DataVersion::fromVersionString('bar');
+        $this->assertSame($testContent, (new TemplateProjectionData($testContent, $dataVersion))->getContent());
+    }
+
+    public function testReturnsTheInjectedDataVersion()
+    {
+        $testContent = 'foo';
+        $dataVersion = DataVersion::fromVersionString('bar');
+        $templateProjectionData = new TemplateProjectionData($testContent, $dataVersion);
+        $this->assertEquals((string) $dataVersion, $templateProjectionData->getDataVersion());
+    }
+}

--- a/tests/Unit/Suites/RestApi/RestApiFactoryTest.php
+++ b/tests/Unit/Suites/RestApi/RestApiFactoryTest.php
@@ -36,6 +36,7 @@ use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
  * @uses   \LizardsAndPumpkins\DataPool\DataPoolReader
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\RestApi\CurrentVersionApiV1GetRequestHandler
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\RestApi\CurrentVersionApiV1PutRequestHandler
+ * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
  */
 class RestApiFactoryTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/Suites/Util/Factory/CommonFactoryTest.php
+++ b/tests/Unit/Suites/Util/Factory/CommonFactoryTest.php
@@ -63,6 +63,8 @@ use LizardsAndPumpkins\Import\Product\UpdateProductCommandHandler;
 use LizardsAndPumpkins\Import\Product\UrlKey\UrlKeyForContextCollector;
 use LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent;
 use LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEventHandler;
+use LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommand;
+use LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommandHandler;
 use LizardsAndPumpkins\Import\SnippetRenderer;
 use LizardsAndPumpkins\Import\Tax\ProductTaxClass;
 use LizardsAndPumpkins\Logging\Logger;
@@ -223,6 +225,8 @@ use LizardsAndPumpkins\Util\Factory\Exception\UndefinedFactoryMethodException;
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\SetCurrentDataVersionCommandHandler
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\CurrentDataVersionWasSetDomainEvent
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\CurrentDataVersionWasSetDomainEventHandler
+ * @uses   \LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommandHandler
+ * @uses   \LizardsAndPumpkins\Import\RootTemplate\UpdateTemplateCommand
  */
 class CommonFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -490,6 +494,14 @@ class CommonFactoryTest extends \PHPUnit_Framework_TestCase
         $result = $this->commonFactory->createUpdateContentBlockCommandHandler($message);
 
         $this->assertInstanceOf(UpdateContentBlockCommandHandler::class, $result);
+    }
+
+    public function testReturnsAnUpdateTemplateCommandHandler()
+    {
+        $message = (new UpdateTemplateCommand('foo', 'bar', DataVersion::fromVersionString('baz')))->toMessage();
+        $result = $this->commonFactory->createUpdateTemplateCommandHandler($message);
+        
+        $this->assertInstanceOf(UpdateTemplateCommandHandler::class, $result);
     }
 
     public function testContentBlockWasUpdatedDomainEventHandlerIsReturned()

--- a/tests/Unit/Suites/Util/Factory/CommonFactoryTest.php
+++ b/tests/Unit/Suites/Util/Factory/CommonFactoryTest.php
@@ -266,7 +266,7 @@ class CommonFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testTemplateWasUpdatedDomainEventHandlerIsReturned()
     {
-        $testEvent = new TemplateWasUpdatedDomainEvent('foo', 'bar');
+        $testEvent = new TemplateWasUpdatedDomainEvent('foo', 'bar', DataVersion::fromVersionString('baz'));
         $result = $this->commonFactory->createTemplateWasUpdatedDomainEventHandler($testEvent->toMessage());
 
         $this->assertInstanceOf(TemplateWasUpdatedDomainEventHandler::class, $result);


### PR DESCRIPTION
Still open: add v2 of the update template API and add support for specifying a data version there, similar to the catalog_import API.