### PR TITLE
Issue #1005: Downgrade phpunit to ^5.7 so it is compatible with PHPStorm 2016.3.2 (current stable)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "league/climate": "^3.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^5.7",
         "lizards-and-pumpkins/coding-standards": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Closes #1005 