### PR TITLE
Issue #1022: Add getHeaders method to HttpResponse interface

### DIFF
--- a/src/Http/ContentDelivery/GenericHttpResponse.php
+++ b/src/Http/ContentDelivery/GenericHttpResponse.php
@@ -87,4 +87,9 @@ class GenericHttpResponse implements HttpResponse
                ($code >= 428 && $code <= 429) || $code === 431 || $code === 451 ||
                ($code >= 500 && $code <= 511) || ($code >= 598 && $code <= 599);
     }
+
+    public function getHeaders(): HttpHeaders
+    {
+        return $this->headers;
+    }
 }

--- a/src/Http/HttpHeaders.php
+++ b/src/Http/HttpHeaders.php
@@ -35,11 +35,16 @@ class HttpHeaders
                 throw new InvalidHttpHeadersException('Can only create HTTP headers from string');
             }
 
-            $normalizedHeaderName = strtolower($headerName);
+            $normalizedHeaderName = self::normalizeHeaderName($headerName);
             $normalizedHeaders[$normalizedHeaderName] = $headerValue;
         }
 
         return new self($normalizedHeaders);
+    }
+
+    private static function normalizeHeaderName(string $headerName): string
+    {
+        return str_replace(' ', '-', ucwords(strtolower(str_replace('-', ' ', $headerName))));
     }
 
     public static function fromGlobalRequestHeaders() : HttpHeaders
@@ -55,7 +60,7 @@ class HttpHeaders
 
     public function get(string $headerName) : string
     {
-        $normalizedHeaderName = strtolower($headerName);
+        $normalizedHeaderName = self::normalizeHeaderName($headerName);
         if (!$this->has($normalizedHeaderName)) {
             throw new HeaderNotPresentException(sprintf('The header "%s" is not present.', $headerName));
         }
@@ -72,6 +77,6 @@ class HttpHeaders
 
     public function has(string $headerName) : bool
     {
-        return array_key_exists(strtolower($headerName), $this->headers);
+        return array_key_exists(self::normalizeHeaderName($headerName), $this->headers);
     }
 }

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace LizardsAndPumpkins\Http;
 
@@ -11,9 +11,11 @@ interface HttpResponse
     const STATUS_BAD_REQUEST = 400;
     const STATUS_NOT_FOUND = 404;
 
-    public function getBody() : string;
+    public function getBody(): string;
 
-    public function getStatusCode() : int;
+    public function getHeaders(): HttpHeaders;
+
+    public function getStatusCode(): int;
 
     public function send();
 }

--- a/src/Http/Routing/HttpResourceNotFoundResponse.php
+++ b/src/Http/Routing/HttpResourceNotFoundResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\Http\Routing;
 
+use LizardsAndPumpkins\Http\HttpHeaders;
 use LizardsAndPumpkins\Http\HttpResponse;
 
 class HttpResourceNotFoundResponse implements HttpResponse
@@ -22,5 +23,10 @@ class HttpResourceNotFoundResponse implements HttpResponse
     {
         http_response_code($this->getStatusCode());
         echo $this->getBody();
+    }
+
+    public function getHeaders(): HttpHeaders
+    {
+        return HttpHeaders::fromArray([]);
     }
 }

--- a/tests/Unit/Suites/Http/ContentDelivery/FrontendFactoryTest.php
+++ b/tests/Unit/Suites/Http/ContentDelivery/FrontendFactoryTest.php
@@ -98,6 +98,7 @@ use PHPUnit\Framework\TestCase;
  * @uses   \LizardsAndPumpkins\Import\RootTemplate\Import\TemplatesApiV2PutRequestHandler
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\RestApi\CurrentVersionApiV1GetRequestHandler
  * @uses   \LizardsAndPumpkins\DataPool\DataVersion\RestApi\CurrentVersionApiV1PutRequestHandler
+ * @uses   \LizardsAndPumpkins\ProductSearch\ContentDelivery\DefaultFullTextCriteriaBuilder
  */
 class FrontendFactoryTest extends TestCase
 {

--- a/tests/Unit/Suites/Http/ContentDelivery/GenericHttpResponseTest.php
+++ b/tests/Unit/Suites/Http/ContentDelivery/GenericHttpResponseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LizardsAndPumpkins\Http\ContentDelivery;
 
 use LizardsAndPumpkins\Http\ContentDelivery\Exception\InvalidStatusCodeException;
+use LizardsAndPumpkins\Http\HttpHeaders;
 use LizardsAndPumpkins\Http\HttpResponse;
 use PHPUnit\Framework\TestCase;
 
@@ -89,7 +90,7 @@ class GenericHttpResponseTest extends TestCase
      */
     public function testGivenHeaderIsIncludedIntoResponse()
     {
-        $customHeaderName = 'foo';
+        $customHeaderName = 'Foo';
         $customHeaderValue = 'bar';
 
         $dummyBody = '';
@@ -129,5 +130,18 @@ class GenericHttpResponseTest extends TestCase
         ob_end_clean();
 
         $this->assertEquals($dummyStatusCode, http_response_code());
+    }
+
+    public function testReturnsHeaders()
+    {
+        $dummyBody = 'foo';
+        $dummyHeaders = ['Bar' => 'baz'];
+        $dummyStatusCode = HttpResponse::STATUS_OK;
+
+        $response = GenericHttpResponse::create($dummyBody, $dummyHeaders, $dummyStatusCode);
+        $headers = $response->getHeaders();
+        $this->assertInstanceOf(HttpHeaders::class, $headers);
+        $this->assertTrue($headers->has('Bar'));
+        $this->assertSame('baz', $headers->get('Bar'));
     }
 }

--- a/tests/Unit/Suites/Http/HttpHeadersTest.php
+++ b/tests/Unit/Suites/Http/HttpHeadersTest.php
@@ -58,7 +58,7 @@ class HttpHeadersTest extends TestCase
 
     public function testAllHeadersAreReturned()
     {
-        $headersArray = ['header 1 name' => 'header 1 value', 'header 2 name' => 'header 2 value'];
+        $headersArray = ['Header-1-Name' => 'header 1 value', 'Header-2-Name' => 'header 2 value'];
         $headers = HttpHeaders::fromArray($headersArray);
 
         $this->assertEquals($headersArray, $headers->getAll());
@@ -101,7 +101,7 @@ class HttpHeadersTest extends TestCase
 
         unset($_SERVER['HTTP_FOO']);
 
-        $this->assertSame(['foo' => $dummyValue], $result->getAll());
+        $this->assertSame(['Foo' => $dummyValue], $result->getAll());
     }
     
     public function testOnlyHttpGlobalsAreUsedForCreatingHeaders()
@@ -117,13 +117,13 @@ class HttpHeadersTest extends TestCase
     
     public function testHeadersCreatedFromGlobalsAreNormalized()
     {
-        $_SERVER['HTTP_FOO'] = 'bar';
+        $_SERVER['HTTP_FOO_BAR'] = 'bar';
 
         $result = HttpHeaders::fromGlobalRequestHeaders();
 
-        unset($_SERVER['HTTP_FOO']);
+        unset($_SERVER['HTTP_FOO_BAR']);
 
-        $this->assertTrue($result->has('foo'));
+        $this->assertTrue($result->has('Foo-Bar'));
 
     }
 }

--- a/tests/Unit/Suites/Http/Routing/HttpResourceNotFoundResponseTest.php
+++ b/tests/Unit/Suites/Http/Routing/HttpResourceNotFoundResponseTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LizardsAndPumpkins\Http\Routing\HttpResourceNotFoundResponse
+ * @uses   \LizardsAndPumpkins\Http\HttpHeaders
  */
 class HttpResourceNotFoundResponseTest extends TestCase
 {
@@ -18,5 +19,11 @@ class HttpResourceNotFoundResponseTest extends TestCase
         ob_end_clean();
 
         $this->assertEquals(404, http_response_code());
+    }
+
+    public function testReturnsEmptyHeaders()
+    {
+        $headers = (new HttpResourceNotFoundResponse())->getHeaders();
+        $this->assertEmpty($headers->getAll());
     }
 }

--- a/tests/Unit/Suites/RestApi/ApiRequestHandlerTest.php
+++ b/tests/Unit/Suites/RestApi/ApiRequestHandlerTest.php
@@ -54,9 +54,9 @@ class ApiRequestHandlerTest extends TestCase
         $response->send();
 
         $expectedHeaders = [
-            'access-control-allow-origin: *',
-            'access-control-allow-methods: *',
-            'content-type: application/json',
+            'Access-Control-Allow-Origin: *',
+            'Access-Control-Allow-Methods: *',
+            'Content-Type: application/json',
         ];
 
         $this->assertArraySubset($expectedHeaders, xdebug_get_headers());


### PR DESCRIPTION
Add getHeaders method to HttpResponse interface to increase decorateability.
Also some other minor changes to make things a little friendlier.

Closes #1022 