### PR TITLE
Issue #1053: Consolidate URL to website mapping

### DIFF
--- a/src/Context/Website/ConfigurableUrlToWebsiteMap.php
+++ b/src/Context/Website/ConfigurableUrlToWebsiteMap.php
@@ -75,6 +75,10 @@ class ConfigurableUrlToWebsiteMap implements UrlToWebsiteMap
         return [$matches[1] => $matches[2]];
     }
 
+    /**
+     * @param string $url
+     * @return string[]
+     */
     private function getWebsiteUrlPrefixAndCodeByUrl(string $url): array
     {
         foreach ($this->urlToWebsiteMap as $urlPrefix => $website) {

--- a/src/Context/Website/ConfigurableUrlToWebsiteMap.php
+++ b/src/Context/Website/ConfigurableUrlToWebsiteMap.php
@@ -89,24 +89,26 @@ class ConfigurableUrlToWebsiteMap implements UrlToWebsiteMap
     public function getWebsiteCodeByUrl(string $url): Website
     {
         list($urlPrefix, $website) = $this->getWebsiteUrlPrefixAndCodeByUrl($url);
+
         return $website;
     }
 
     public function getRequestPathWithoutWebsitePrefix(string $url): string
     {
         list($urlPrefix, $website) = $this->getWebsiteUrlPrefixAndCodeByUrl($url);
-        $pathWithoutPrefix = substr($url, strlen($urlPrefix));
 
-        return $this->hasQueryParameter($url) ? $this->removeQueryParameter($pathWithoutPrefix) : $pathWithoutPrefix;
+        $relevantUrlParts = $this->removeQueryAndAnchor($url);
+
+        return substr($relevantUrlParts, strlen($urlPrefix));
     }
 
-    private function hasQueryParameter(string $url): bool
+    private function removeQueryAndAnchor(string $url): string
     {
-        return strrpos($url, '?') !== false;
-    }
+        $parts = parse_url($url);
 
-    private function removeQueryParameter($pathWithoutPrefix): string
-    {
-        return substr($pathWithoutPrefix, 0, strrpos($pathWithoutPrefix, '?'));
+        return (isset($parts['scheme']) ? $parts['scheme'] . '://' : '') .
+               ($parts['host'] ?? '') .
+               (isset($parts['port']) ? ':' . $parts['port'] : '') .
+               (isset($parts['path']) ? $parts['path'] : '/');
     }
 }

--- a/src/Context/Website/ConfigurableUrlToWebsiteMap.php
+++ b/src/Context/Website/ConfigurableUrlToWebsiteMap.php
@@ -67,7 +67,7 @@ class ConfigurableUrlToWebsiteMap implements UrlToWebsiteMap
      */
     private static function splitConfigRecord(string $mapping): array
     {
-        if (!preg_match('/^([^=]+)=(.+)/', $mapping, $matches)) {
+        if (! preg_match('/^([^=]+)=(.+)/', $mapping, $matches)) {
             $message = sprintf('Unable to parse the website to code mapping record "%s"', $mapping);
             throw new InvalidWebsiteMapConfigRecordException($message);
         }

--- a/src/Context/Website/ConfigurableUrlToWebsiteMap.php
+++ b/src/Context/Website/ConfigurableUrlToWebsiteMap.php
@@ -43,7 +43,7 @@ class ConfigurableUrlToWebsiteMap implements UrlToWebsiteMap
      * @param string[] $map
      * @return Website[]
      */
-    private static function createWebsites(array $map) : array
+    private static function createWebsites(array $map): array
     {
         return array_reduce(array_keys($map), function (array $carry, $url) use ($map) {
             return array_merge($carry, [$url => Website::fromString($map[$url])]);
@@ -58,14 +58,14 @@ class ConfigurableUrlToWebsiteMap implements UrlToWebsiteMap
     {
         $pairs = array_map([self::class, 'splitConfigRecord'], explode(self::RECORD_SEPARATOR, $configValue));
 
-        return self::flatten($pairs);
+        return array_merge(...$pairs);
     }
 
     /**
      * @param string $mapping
      * @return string[]
      */
-    private static function splitConfigRecord(string $mapping) : array
+    private static function splitConfigRecord(string $mapping): array
     {
         if (!preg_match('/^([^=]+)=(.+)/', $mapping, $matches)) {
             $message = sprintf('Unable to parse the website to code mapping record "%s"', $mapping);
@@ -75,25 +75,26 @@ class ConfigurableUrlToWebsiteMap implements UrlToWebsiteMap
         return [$matches[1] => $matches[2]];
     }
 
-    /**
-     * @param array[] $array
-     * @return string[]
-     */
-    private static function flatten(array $array) : array
+    private function getWebsiteUrlPrefixAndCodeByUrl(string $url): array
     {
-        return array_reduce($array, function (array $carry, array $pair) {
-            return array_merge($carry, $pair);
-        }, []);
-    }
-
-    public function getWebsiteCodeByUrl(string $url) : Website
-    {
-        foreach ($this->urlToWebsiteMap as $urlPattern => $website) {
-            if (stripos($url, $urlPattern) === 0) {
-                return $website;
+        foreach ($this->urlToWebsiteMap as $urlPrefix => $website) {
+            if (stripos($url, $urlPrefix) === 0) {
+                return [$urlPrefix, $website];
             }
         }
 
-        throw new UnknownWebsiteUrlException(sprintf('No website code found for url "%s"', $url));
+        throw new UnknownWebsiteUrlException(sprintf('No website found for url "%s"', $url));
+    }
+
+    public function getWebsiteCodeByUrl(string $url): Website
+    {
+        list($urlPrefix, $website) = $this->getWebsiteUrlPrefixAndCodeByUrl($url);
+        return $website;
+    }
+
+    public function getRequestPathWithoutWebsitePrefix(string $url): string
+    {
+        list($urlPrefix, $website) = $this->getWebsiteUrlPrefixAndCodeByUrl($url);
+        return substr($url, strlen($urlPrefix));
     }
 }

--- a/src/Context/Website/ConfigurableUrlToWebsiteMap.php
+++ b/src/Context/Website/ConfigurableUrlToWebsiteMap.php
@@ -95,6 +95,18 @@ class ConfigurableUrlToWebsiteMap implements UrlToWebsiteMap
     public function getRequestPathWithoutWebsitePrefix(string $url): string
     {
         list($urlPrefix, $website) = $this->getWebsiteUrlPrefixAndCodeByUrl($url);
-        return substr($url, strlen($urlPrefix));
+        $pathWithoutPrefix = substr($url, strlen($urlPrefix));
+
+        return $this->hasQueryParameter($url) ? $this->removeQueryParameter($pathWithoutPrefix) : $pathWithoutPrefix;
+    }
+
+    private function hasQueryParameter(string $url): bool
+    {
+        return strrpos($url, '?') !== false;
+    }
+
+    private function removeQueryParameter($pathWithoutPrefix): string
+    {
+        return substr($pathWithoutPrefix, 0, strrpos($pathWithoutPrefix, '?'));
     }
 }

--- a/src/Context/Website/UrlToWebsiteMap.php
+++ b/src/Context/Website/UrlToWebsiteMap.php
@@ -6,5 +6,7 @@ namespace LizardsAndPumpkins\Context\Website;
 
 interface UrlToWebsiteMap
 {
-    public function getWebsiteCodeByUrl(string $url) : Website;
+    public function getWebsiteCodeByUrl(string $url): Website;
+    
+    public function getRequestPathWithoutWebsitePrefix(string $url): string;
 }

--- a/src/Http/ContentDelivery/FrontendFactory.php
+++ b/src/Http/ContentDelivery/FrontendFactory.php
@@ -324,6 +324,7 @@ class FrontendFactory implements Factory
             $this->getMasterFactory()->createDataPoolReader(),
             $this->getMasterFactory()->createProductSearchResultMetaSnippetKeyGenerator(),
             $this->getMasterFactory()->createProductSearchFacetFiltersToIncludeInResult(),
+            $this->getMasterFactory()->createUrlToWebsiteMap(),
             $this->getMasterFactory()->createProductListingPageContentBuilder(),
             $this->getMasterFactory()->createProductListingPageRequest(),
             $this->getMasterFactory()->createProductSearchService(),

--- a/src/Http/ContentDelivery/FrontendFactory.php
+++ b/src/Http/ContentDelivery/FrontendFactory.php
@@ -88,6 +88,7 @@ class FrontendFactory implements Factory
             $this->getMasterFactory()->createDataPoolReader(),
             $this->getMasterFactory()->createProductListingSnippetKeyGenerator(),
             $this->getMasterFactory()->createProductListingFacetFiltersToIncludeInResult(),
+            $this->getMasterFactory()->createUrlToWebsiteMap(),
             $this->getMasterFactory()->createProductListingPageContentBuilder(),
             $this->getMasterFactory()->createSelectProductListingRobotsMetaTagContent(),
             $this->getMasterFactory()->createProductListingPageRequest(),

--- a/src/Http/ContentDelivery/FrontendFactory.php
+++ b/src/Http/ContentDelivery/FrontendFactory.php
@@ -75,6 +75,7 @@ class FrontendFactory implements Factory
             $this->createContext(),
             $this->getMasterFactory()->createDataPoolReader(),
             $this->getMasterFactory()->createPageBuilder(),
+            $this->getMasterFactory()->createUrlToWebsiteMap(),
             $this->getMasterFactory()->getTranslatorRegistry(),
             $this->getMasterFactory()->createProductDetailPageMetaSnippetKeyGenerator()
         );

--- a/src/Http/HttpRequest.php
+++ b/src/Http/HttpRequest.php
@@ -80,6 +80,10 @@ abstract class HttpRequest
         return $this->url;
     }
 
+    /**
+     * @deprecated Use UrlToWebsiteMap::getRequestPathWithoutWebsitePrefix() instead.
+     * @codeCoverageIgnore
+     */
     public function getPathWithoutWebsitePrefix() : string
     {
         return $this->getUrl()->getPathWithoutWebsitePrefix();

--- a/src/Http/HttpUrl.php
+++ b/src/Http/HttpUrl.php
@@ -84,17 +84,16 @@ class HttpUrl
         return $schema . '//' . $this->host . $port . $this->path . $query;
     }
 
+    /**
+     * @deprecated Use UrlToWebsiteMap::getRequestPathWithoutWebsitePrefix() instead.
+     * @codeCoverageIgnore
+     */
     public function getPathWithoutWebsitePrefix() : string
     {
-        $websitePrefix = $this->getAppEntryPointPath();
+        $websitePrefix = preg_replace('#/[^/]*$#', '', $_SERVER['SCRIPT_NAME']);
         return ltrim(preg_replace('/^' . preg_quote($websitePrefix, '/') . '/', '', $this->path), '/');
     }
-
-    private function getAppEntryPointPath() : string
-    {
-        return preg_replace('#/[^/]*$#', '', $_SERVER['SCRIPT_NAME']);
-    }
-
+    
     public function hasQueryParameter(string $queryParameter) : bool
     {
         return isset($this->query[$queryParameter]);

--- a/src/ProductDetail/ProductDetailViewRequestHandler.php
+++ b/src/ProductDetail/ProductDetailViewRequestHandler.php
@@ -6,6 +6,7 @@ namespace LizardsAndPumpkins\ProductDetail;
 
 use LizardsAndPumpkins\Context\Context;
 use LizardsAndPumpkins\Context\Locale\Locale;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\DataPoolReader;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Exception\KeyNotFoundException;
 use LizardsAndPumpkins\Http\ContentDelivery\PageBuilder\PageBuilder;
@@ -55,10 +56,16 @@ class ProductDetailViewRequestHandler implements HttpRequestHandler
      */
     private $translatorRegistry;
 
+    /**
+     * @var UrlToWebsiteMap
+     */
+    private $urlToWebsiteMap;
+
     public function __construct(
         Context $context,
         DataPoolReader $dataPoolReader,
         PageBuilder $pageBuilder,
+        UrlToWebsiteMap $urlToWebsiteMap,
         TranslatorRegistry $translatorRegistry,
         SnippetKeyGenerator $snippetKeyGenerator
     ) {
@@ -67,6 +74,7 @@ class ProductDetailViewRequestHandler implements HttpRequestHandler
         $this->pageBuilder = $pageBuilder;
         $this->translatorRegistry = $translatorRegistry;
         $this->snippetKeyGenerator = $snippetKeyGenerator;
+        $this->urlToWebsiteMap = $urlToWebsiteMap;
     }
 
     public function canProcess(HttpRequest $request) : bool
@@ -104,7 +112,7 @@ class ProductDetailViewRequestHandler implements HttpRequestHandler
             }
         }
     }
-
+                                                          
     /**
      * @param string $metaInfoSnippetKey
      * @return mixed
@@ -121,7 +129,7 @@ class ProductDetailViewRequestHandler implements HttpRequestHandler
 
     private function getMetaInfoSnippetKey(HttpRequest $request) : string
     {
-        $urlKey = $request->getPathWithoutWebsitePrefix();
+        $urlKey = $this->urlToWebsiteMap->getRequestPathWithoutWebsitePrefix((string) $request->getUrl());
         $metaInfoSnippetKey = $this->snippetKeyGenerator->getKeyForContext(
             $this->context,
             [PageMetaInfoSnippetContent::URL_KEY => $urlKey]

--- a/src/ProductListing/ContentDelivery/ProductSearchRequestHandler.php
+++ b/src/ProductListing/ContentDelivery/ProductSearchRequestHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LizardsAndPumpkins\ProductListing\ContentDelivery;
 
 use LizardsAndPumpkins\Context\Context;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\DataPoolReader;
 use LizardsAndPumpkins\DataPool\SearchEngine\FacetFiltersToIncludeInResult;
 use LizardsAndPumpkins\DataPool\SearchEngine\Query\SortBy;
@@ -73,11 +74,17 @@ class ProductSearchRequestHandler implements HttpRequestHandler
      */
     private $availableSortBy;
 
+    /**
+     * @var UrlToWebsiteMap
+     */
+    private $urlToWebsiteMap;
+
     public function __construct(
         Context $context,
         DataPoolReader $dataPoolReader,
         SnippetKeyGenerator $metaInfoSnippetKeyGenerator,
         FacetFiltersToIncludeInResult $facetFiltersToIncludeInResult,
+        UrlToWebsiteMap $urlToWebsiteMap,
         ProductListingPageContentBuilder $productListingPageContentBuilder,
         ProductListingPageRequest $productListingPageRequest,
         ProductSearchService $productSearchService,
@@ -95,6 +102,7 @@ class ProductSearchRequestHandler implements HttpRequestHandler
         $this->fullTextCriteriaBuilder = $fullTextCriteriaBuilder;
         $this->defaultSortBy = $defaultSortBy;
         $this->availableSortBy = $availableSortBy;
+        $this->urlToWebsiteMap = $urlToWebsiteMap;
     }
 
     public function canProcess(HttpRequest $request) : bool
@@ -136,7 +144,8 @@ class ProductSearchRequestHandler implements HttpRequestHandler
 
     private function isValidSearchRequest(HttpRequest $request) : bool
     {
-        $urlPathWithoutTrailingSlash = rtrim($request->getPathWithoutWebsitePrefix(), '/');
+        $pathWithoutWebsitePrefix = $this->urlToWebsiteMap->getRequestPathWithoutWebsitePrefix((string) $request->getUrl());
+        $urlPathWithoutTrailingSlash = rtrim($pathWithoutWebsitePrefix, '/');
 
         if (self::SEARCH_RESULTS_SLUG !== $urlPathWithoutTrailingSlash) {
             return false;

--- a/src/ProductRelations/ContentDelivery/ProductRelationsApiV1GetRequestHandler.php
+++ b/src/ProductRelations/ContentDelivery/ProductRelationsApiV1GetRequestHandler.php
@@ -53,7 +53,7 @@ class ProductRelationsApiV1GetRequestHandler extends ApiRequestHandler
 
     final protected function getResponse(HttpRequest $request): HttpResponse
     {
-        if (!$this->canProcess($request)) {
+        if (! $this->canProcess($request)) {
             throw $this->getUnableToProcessRequestException($request);
         }
 

--- a/src/ProductRelations/ProductRelationsFactory.php
+++ b/src/ProductRelations/ProductRelationsFactory.php
@@ -35,6 +35,7 @@ class ProductRelationsFactory implements FactoryWithCallback
     {
         return new ProductRelationsApiV1GetRequestHandler(
             $this->getMasterFactory()->createProductRelationsService(),
+            $this->getMasterFactory()->createUrlToWebsiteMap(),
             $this->getMasterFactory()->createContextBuilder()
         );
     }

--- a/src/ProductSearch/ContentDelivery/ProductSearchApiV1GetRequestHandler.php
+++ b/src/ProductSearch/ContentDelivery/ProductSearchApiV1GetRequestHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LizardsAndPumpkins\ProductSearch\ContentDelivery;
 
 use LizardsAndPumpkins\Context\ContextBuilder;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\SearchEngine\FacetFilterRequestSimpleField;
 use LizardsAndPumpkins\DataPool\SearchEngine\FacetFiltersToIncludeInResult;
 use LizardsAndPumpkins\DataPool\SearchEngine\Query\SortBy;
@@ -73,9 +74,15 @@ class ProductSearchApiV1GetRequestHandler extends ApiRequestHandler
      */
     private $searchEngineConfiguration;
 
+    /**
+     * @var UrlToWebsiteMap
+     */
+    private $urlToWebsiteMap;
+
     public function __construct(
         ProductSearchService $productSearchService,
         ContextBuilder $contextBuilder,
+        UrlToWebsiteMap $urlToWebsiteMap,
         FullTextCriteriaBuilder $fullTextCriteriaBuilder,
         SelectedFiltersParser $selectedFiltersParser,
         CriteriaParser $criteriaParser,
@@ -87,6 +94,7 @@ class ProductSearchApiV1GetRequestHandler extends ApiRequestHandler
         $this->selectedFiltersParser = $selectedFiltersParser;
         $this->criteriaParser = $criteriaParser;
         $this->searchEngineConfiguration = $searchEngineConfiguration;
+        $this->urlToWebsiteMap = $urlToWebsiteMap;
     }
 
     public function canProcess(HttpRequest $request) : bool
@@ -133,7 +141,9 @@ class ProductSearchApiV1GetRequestHandler extends ApiRequestHandler
      */
     private function getRequestPathParts(HttpRequest $request) : array
     {
-        return explode('/', trim($request->getPathWithoutWebsitePrefix(), '/'));
+        $pathWithoutWebsitePrefix = $this->urlToWebsiteMap->getRequestPathWithoutWebsitePrefix((string) $request->getUrl());
+
+        return explode('/', trim($pathWithoutWebsitePrefix, '/'));
     }
 
     private function createQueryOptions(HttpRequest $request) : QueryOptions

--- a/src/ProductSearch/ContentDelivery/ProductSearchFactory.php
+++ b/src/ProductSearch/ContentDelivery/ProductSearchFactory.php
@@ -33,6 +33,7 @@ class ProductSearchFactory implements FactoryWithCallback
         return new ProductSearchApiV1GetRequestHandler(
             $this->getMasterFactory()->createProductSearchService(),
             $this->getMasterFactory()->createContextBuilder(),
+            $this->getMasterFactory()->createUrlToWebsiteMap(),
             $this->getMasterFactory()->createFullTextCriteriaBuilder(),
             $this->getMasterFactory()->createSelectedFiltersParser(),
             $this->getMasterFactory()->createCriteriaParser(),

--- a/src/RestApi/ApiRouter.php
+++ b/src/RestApi/ApiRouter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\RestApi;
 
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\Http\HttpRequest;
 use LizardsAndPumpkins\Http\Routing\HttpRouter;
 
@@ -16,9 +17,15 @@ class ApiRouter implements HttpRouter
      */
     private $requestHandlerLocator;
 
-    public function __construct(ApiRequestHandlerLocator $requestHandlerLocator)
+    /**
+     * @var UrlToWebsiteMap
+     */
+    private $urlToWebsiteMap;
+
+    public function __construct(ApiRequestHandlerLocator $requestHandlerLocator, UrlToWebsiteMap $urlToWebsiteMap)
     {
         $this->requestHandlerLocator = $requestHandlerLocator;
+        $this->urlToWebsiteMap = $urlToWebsiteMap;
     }
 
     /**
@@ -27,7 +34,7 @@ class ApiRouter implements HttpRouter
      */
     public function route(HttpRequest $request)
     {
-        $urlPath = trim($request->getPathWithoutWebsitePrefix(), '/');
+        $urlPath = trim($this->urlToWebsiteMap->getRequestPathWithoutWebsitePrefix((string) $request->getUrl()), '/');
         $urlToken = explode('/', $urlPath);
 
         if (self::API_URL_PREFIX !== array_shift($urlToken)) {

--- a/src/RestApi/RestApiFactory.php
+++ b/src/RestApi/RestApiFactory.php
@@ -28,7 +28,10 @@ class RestApiFactory implements Factory
 
     public function createApiRouter(): ApiRouter
     {
-        return new ApiRouter($this->getApiRequestHandlerLocator());
+        return new ApiRouter(
+            $this->getApiRequestHandlerLocator(),
+            $this->getMasterFactory()->createUrlToWebsiteMap()
+        );
     }
 
     public function createCatalogImportApiV1PutRequestHandler(): CatalogImportApiV1PutRequestHandler

--- a/tests/Integration/Suites/FrontendRenderingTest.php
+++ b/tests/Integration/Suites/FrontendRenderingTest.php
@@ -7,6 +7,7 @@ namespace LizardsAndPumpkins;
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Context\Locale\Locale;
 use LizardsAndPumpkins\Context\Website\IntegrationTestUrlToWebsiteMap;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\KeyGenerator\GenericSnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
@@ -162,10 +163,13 @@ class FrontendRenderingTest extends AbstractIntegrationTest
             Locale::CONTEXT_CODE => 'foo_BAR'
         ]);
         
+        /** @var UrlToWebsiteMap $urlToWebsiteMap */
+        $urlToWebsiteMap = $this->factory->createUrlToWebsiteMap();
         $metaSnippetKeyGenerator = $this->factory->createProductDetailPageMetaSnippetKeyGenerator();
+        $pathWithoutWebsitePrefix = $urlToWebsiteMap->getRequestPathWithoutWebsitePrefix((string) $this->request->getUrl());
         $productDetailPageMetaSnippetKey = $metaSnippetKeyGenerator->getKeyForContext(
             $context,
-            [PageMetaInfoSnippetContent::URL_KEY => $this->request->getPathWithoutWebsitePrefix()]
+            [PageMetaInfoSnippetContent::URL_KEY => $pathWithoutWebsitePrefix]
         );
 
         $this->addSnippetsFixtureToKeyValueStorage($productDetailPageMetaSnippetKey, $context);

--- a/tests/Integration/Suites/FrontendRenderingTest.php
+++ b/tests/Integration/Suites/FrontendRenderingTest.php
@@ -6,6 +6,7 @@ namespace LizardsAndPumpkins;
 
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Context\Locale\Locale;
+use LizardsAndPumpkins\Context\Website\IntegrationTestUrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\KeyGenerator\GenericSnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
@@ -141,6 +142,7 @@ class FrontendRenderingTest extends AbstractIntegrationTest
             $context,
             $dataPoolReader,
             new GenericPageBuilder($dataPoolReader, $this->snippetKeyGeneratorLocator, $logger),
+            new IntegrationTestUrlToWebsiteMap(),
             $this->factory->getTranslatorRegistry(),
             $productDetailPageMetaSnippetKeyGenerator
         );

--- a/tests/Integration/Util/Context/Website/IntegrationTestUrlToWebsiteMap.php
+++ b/tests/Integration/Util/Context/Website/IntegrationTestUrlToWebsiteMap.php
@@ -13,6 +13,6 @@ class IntegrationTestUrlToWebsiteMap implements UrlToWebsiteMap
 
     public function getRequestPathWithoutWebsitePrefix(string $url): string
     {
-        return preg_match('#^https?://[^/]+/(?<path>.+)#', $url, $m) ? $m['path'] : '';
+        return preg_match('#^https?://[^/]+/(?<pathWithoutQuery>[^?]+)#', $url, $m) ? $m['pathWithoutQuery'] : '';
     }
 }

--- a/tests/Integration/Util/Context/Website/IntegrationTestUrlToWebsiteMap.php
+++ b/tests/Integration/Util/Context/Website/IntegrationTestUrlToWebsiteMap.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LizardsAndPumpkins\Context\Website;
+
+class IntegrationTestUrlToWebsiteMap implements UrlToWebsiteMap
+{
+    public function getWebsiteCodeByUrl(string $url): Website
+    {
+        return Website::fromString('foo');
+    }
+
+    public function getRequestPathWithoutWebsitePrefix(string $url): string
+    {
+        return preg_match('#^https?://[^/]+/(?<path>.+)#', $url, $m) ? $m['path'] : '';
+    }
+}

--- a/tests/Integration/Util/IntegrationTestFactory.php
+++ b/tests/Integration/Util/IntegrationTestFactory.php
@@ -11,6 +11,8 @@ use LizardsAndPumpkins\Context\Country\IntegrationTestContextCountry;
 use LizardsAndPumpkins\Context\IntegrationTestContextSource;
 use LizardsAndPumpkins\Context\Locale\IntegrationTestContextLocale;
 use LizardsAndPumpkins\Context\Website\IntegrationTestContextWebsite;
+use LizardsAndPumpkins\Context\Website\IntegrationTestUrlToWebsiteMap;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\KeyValueStore\InMemoryKeyValueStore;
 use LizardsAndPumpkins\Import\FileStorage\FileStorageReader;
 use LizardsAndPumpkins\Import\FileStorage\FileStorageWriter;
@@ -443,7 +445,12 @@ class IntegrationTestFactory implements Factory, MessageQueueFactory
     {
         return new IntegrationTestContextWebsite();
     }
-
+    
+    public function createUrlToWebsiteMap() : UrlToWebsiteMap
+    {
+        return new IntegrationTestUrlToWebsiteMap();
+    }
+    
     public function getMaxAllowedProductsPerSearchResultsPage() : int
     {
         return 120;

--- a/tests/Unit/Suites/Context/Website/ConfigurableUrlToWebsiteMapTest.php
+++ b/tests/Unit/Suites/Context/Website/ConfigurableUrlToWebsiteMapTest.php
@@ -109,7 +109,7 @@ class ConfigurableUrlToWebsiteMapTest extends TestCase
         $this->assertSame('foo', $websiteMap->getRequestPathWithoutWebsitePrefix('http://example.com/foo'));
     }
 
-    public function testRturnsTheRequestPathWithoutUrlPrefixWithoutQueryArguments()
+    public function testReturnsTheRequestPathWithoutUrlPrefixWithoutQueryArguments()
     {
         $testMap = 'http://example.com/aa/=foo|http://example.com/=bar';
         $this->stubConfigReader->method('get')->with(ConfigurableUrlToWebsiteMap::CONFIG_KEY)->willReturn($testMap);

--- a/tests/Unit/Suites/Context/Website/ConfigurableUrlToWebsiteMapTest.php
+++ b/tests/Unit/Suites/Context/Website/ConfigurableUrlToWebsiteMapTest.php
@@ -105,7 +105,16 @@ class ConfigurableUrlToWebsiteMapTest extends TestCase
         $this->stubConfigReader->method('get')->with(ConfigurableUrlToWebsiteMap::CONFIG_KEY)->willReturn($testMap);
 
         $websiteMap = ConfigurableUrlToWebsiteMap::fromConfig($this->stubConfigReader);
-        $this->assertSame('a/b/c?d=e', $websiteMap->getRequestPathWithoutWebsitePrefix('http://example.com/aa/a/b/c?d=e'));
+        $this->assertSame('a/b/c', $websiteMap->getRequestPathWithoutWebsitePrefix('http://example.com/aa/a/b/c'));
         $this->assertSame('foo', $websiteMap->getRequestPathWithoutWebsitePrefix('http://example.com/foo'));
+    }
+
+    public function testRturnsTheRequestPathWithoutUrlPrefixWithoutQueryArguments()
+    {
+        $testMap = 'http://example.com/aa/=foo|http://example.com/=bar';
+        $this->stubConfigReader->method('get')->with(ConfigurableUrlToWebsiteMap::CONFIG_KEY)->willReturn($testMap);
+
+        $websiteMap = ConfigurableUrlToWebsiteMap::fromConfig($this->stubConfigReader);
+        $this->assertSame('a/b/c', $websiteMap->getRequestPathWithoutWebsitePrefix('http://example.com/aa/a/b/c?a=b'));
     }
 }

--- a/tests/Unit/Suites/Context/Website/ConfigurableUrlToWebsiteMapTest.php
+++ b/tests/Unit/Suites/Context/Website/ConfigurableUrlToWebsiteMapTest.php
@@ -37,7 +37,7 @@ class ConfigurableUrlToWebsiteMapTest extends TestCase
         $this->assertInstanceOf(ConfigurableUrlToWebsiteMap::class, $result);
     }
 
-    public function testExceptionIsThrownIfGivenUrlMatchesNoneOfWebsites()
+    public function testThrowsExceptionIfGivenUrlMatchesNoneOfWebsites()
     {
         $url = 'http://www.example.com/';
 
@@ -74,7 +74,7 @@ class ConfigurableUrlToWebsiteMapTest extends TestCase
     /**
      * @return array[]
      */
-    public function websiteMapProvider() : array
+    public function websiteMapProvider(): array
     {
         return [
             ['http://example.com/=foo|https://127.0.0.1=bar', 'http://example.com/', 'foo'],
@@ -88,17 +88,6 @@ class ConfigurableUrlToWebsiteMapTest extends TestCase
         ];
     }
 
-    public function testThrowsAnExceptionIfTheWebsiteCanNotBeDetermined()
-    {
-        $url = 'http://www.example.com/';
-
-        $this->expectException(UnknownWebsiteUrlException::class);
-        $this->expectExceptionMessage(sprintf('No website found for url "%s"', $url));
-
-        $websiteMap = ConfigurableUrlToWebsiteMap::fromConfig($this->stubConfigReader);
-        $websiteMap->getRequestPathWithoutWebsitePrefix($url);
-    }
-    
     public function testReturnsTheRequestPathWithoutUrlPrefix()
     {
         $testMap = 'http://example.com/aa/=foo|http://example.com/=bar';

--- a/tests/Unit/Suites/Http/AbstractHttpRequestTest.php
+++ b/tests/Unit/Suites/Http/AbstractHttpRequestTest.php
@@ -65,24 +65,7 @@ abstract class AbstractHttpRequestTest extends TestCase
 
         $this->assertSame($stubHttpUrl, $result);
     }
-
-    public function testGettingUrlPathWithoutWebsitePrefixIsDelegatedToHttpUrl()
-    {
-        $path = 'foo';
-
-        /** @var HttpUrl|\PHPUnit_Framework_MockObject_MockObject $stubHttpUrl */
-        $stubHttpUrl = $this->createMock(HttpUrl::class);
-        $stubHttpUrl->method('getPathWithoutWebsitePrefix')->willReturn($path);
-
-        $httpRequest = HttpRequest::fromParameters(
-            HttpRequest::METHOD_GET,
-            $stubHttpUrl,
-            HttpHeaders::fromArray([]),
-            new HttpRequestBody('')
-        );
-        $this->assertSame($path, $httpRequest->getPathWithoutWebsitePrefix());
-    }
-
+    
     public function testUnsupportedRequestMethodExceptionIsThrown()
     {
         /** @var HttpUrl|\PHPUnit_Framework_MockObject_MockObject $stubHttpUrl */

--- a/tests/Unit/Suites/Http/HttpUrlTest.php
+++ b/tests/Unit/Suites/Http/HttpUrlTest.php
@@ -60,20 +60,7 @@ class HttpUrlTest extends TestCase
         $this->expectException(InvalidUrlStringException::class);
         HttpUrl::fromString('this is not a valid url');
     }
-
-    public function testReturnsPathWithoutWebsitePrefix()
-    {
-        $originalScriptName = $_SERVER['SCRIPT_NAME'];
-        $_SERVER['SCRIPT_NAME'] = '/path/to/index.php';
-
-        $url = HttpUrl::fromString('http://www.example.com/path/to/some-page');
-        $result = $url->getPathWithoutWebsitePrefix();
-
-        $_SERVER['SCRIPT_NAME'] = $originalScriptName;
-
-        $this->assertEquals('some-page', $result);
-    }
-
+    
     public function testReturnsFalseIfQueryParameterIsNotSet()
     {
         $url = HttpUrl::fromString('http://example.com');

--- a/tests/Unit/Suites/ProductListing/ContentDelivery/ProductListingRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductListing/ContentDelivery/ProductListingRequestHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LizardsAndPumpkins\ProductListing\ContentDelivery;
 
 use LizardsAndPumpkins\Context\Context;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\DataPoolReader;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Exception\KeyNotFoundException;
@@ -57,6 +58,11 @@ class ProductListingRequestHandlerTest extends TestCase
      * @var HttpRequest|\PHPUnit_Framework_MockObject_MockObject
      */
     private $stubRequest;
+
+    /**
+     * @var UrlToWebsiteMap|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $stubUrlToWebsiteMap;
 
     private function prepareMockDataPoolReader(int $numberOfResults)
     {
@@ -133,6 +139,8 @@ class ProductListingRequestHandlerTest extends TestCase
         $this->mockProductListingPageRequest = $this->createStubProductListingPageRequest();
 
         $this->stubRequest = $this->createMock(HttpRequest::class);
+        
+        $this->stubUrlToWebsiteMap = $this->createMock(UrlToWebsiteMap::class);
 
         $stubDefaultSortBy = $this->createMock(SortBy::class);
         $this->mockProductSearchService = $this->createMock(ProductSearchService::class);
@@ -142,6 +150,7 @@ class ProductListingRequestHandlerTest extends TestCase
             $this->mockDataPoolReader,
             $stubSnippetKeyGenerator,
             $stubFacetFilterRequest,
+            $this->stubUrlToWebsiteMap,
             $stubProductListingPageContentBuilder,
             $stubSelectRobotsMetaTagContent,
             $this->mockProductListingPageRequest,

--- a/tests/Unit/Suites/ProductRelations/ContentDelivery/ProductRelationsApiV1GetRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductRelations/ContentDelivery/ProductRelationsApiV1GetRequestHandlerTest.php
@@ -6,6 +6,7 @@ namespace LizardsAndPumpkins\ProductRelations\ContentDelivery;
 
 use LizardsAndPumpkins\Context\Context;
 use LizardsAndPumpkins\Context\ContextBuilder;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\RestApi\ApiRequestHandler;
 use LizardsAndPumpkins\Http\HttpRequest;
 use PHPUnit\Framework\TestCase;
@@ -49,13 +50,20 @@ class ProductRelationsApiV1GetRequestHandlerTest extends TestCase
      */
     private $stubContextBuilder;
 
+    /**
+     * @var UrlToWebsiteMap|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $stubUrlToWebsiteMap;
+
     protected function setUp()
     {
         $this->mockProductRelationsService = $this->createMock(ProductRelationsService::class);
         $this->stubContextBuilder = $this->createMock(ContextBuilder::class);
+        $this->stubUrlToWebsiteMap = $this->createMock(UrlToWebsiteMap::class);
 
         $this->requestHandler = new ProductRelationsApiV1GetRequestHandler(
             $this->mockProductRelationsService,
+            $this->stubUrlToWebsiteMap,
             $this->stubContextBuilder
         );
 
@@ -73,7 +81,7 @@ class ProductRelationsApiV1GetRequestHandlerTest extends TestCase
     public function testItCanNotProcessNonHttpGetRequestTypes(string $nonGetRequestMethod)
     {
         $this->stubRequest->method('getMethod')->willReturn($nonGetRequestMethod);
-        $this->stubRequest->method('getPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
+        $this->stubUrlToWebsiteMap->method('getRequestPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
         $message = sprintf('%s request should NOT be able to be processed', $nonGetRequestMethod);
         $this->assertFalse($this->requestHandler->canProcess($this->stubRequest), $message);
     }
@@ -96,7 +104,7 @@ class ProductRelationsApiV1GetRequestHandlerTest extends TestCase
     public function testItCanNotProcessNonMatchingGetRequests(string $nonMatchingRequestPath)
     {
         $this->stubRequest->method('getMethod')->willReturn(HttpRequest::METHOD_GET);
-        $this->stubRequest->method('getPathWithoutWebsitePrefix')->willReturn($nonMatchingRequestPath);
+        $this->stubUrlToWebsiteMap->method('getRequestPathWithoutWebsitePrefix')->willReturn($nonMatchingRequestPath);
         $message = sprintf('GET request to "%s" should NOT be able to be processed', $nonMatchingRequestPath);
         $this->assertFalse($this->requestHandler->canProcess($this->stubRequest), $message);
     }
@@ -114,7 +122,7 @@ class ProductRelationsApiV1GetRequestHandlerTest extends TestCase
     public function testItCanProcessMatchingGetRequests()
     {
         $this->stubRequest->method('getMethod')->willReturn(HttpRequest::METHOD_GET);
-        $this->stubRequest->method('getPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
+        $this->stubUrlToWebsiteMap->method('getRequestPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
         $message = sprintf('Not able to process a GET request to "%s"', $this->testMatchingRequestPath);
         $this->assertTrue($this->requestHandler->canProcess($this->stubRequest), $message);
     }
@@ -122,7 +130,7 @@ class ProductRelationsApiV1GetRequestHandlerTest extends TestCase
     public function testItThrowsAnExceptionIfANonProcessableRequestIsPassed()
     {
         $this->stubRequest->method('getMethod')->willReturn(HttpRequest::METHOD_POST);
-        $this->stubRequest->method('getPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
+        $this->stubUrlToWebsiteMap->method('getRequestPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
 
         $response = $this->requestHandler->process($this->stubRequest);
         $expectedResponseBody = json_encode([
@@ -146,7 +154,7 @@ class ProductRelationsApiV1GetRequestHandlerTest extends TestCase
             ->willReturn($testProductData);
 
         $this->stubRequest->method('getMethod')->willReturn(HttpRequest::METHOD_GET);
-        $this->stubRequest->method('getPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
+        $this->stubUrlToWebsiteMap->method('getRequestPathWithoutWebsitePrefix')->willReturn($this->testMatchingRequestPath);
 
         $stubContext = $this->createMock(Context::class);
 

--- a/tests/Unit/Util/UnitTestFactory.php
+++ b/tests/Unit/Util/UnitTestFactory.php
@@ -7,6 +7,7 @@ namespace LizardsAndPumpkins;
 use LizardsAndPumpkins\Context\BaseUrl\BaseUrlBuilder;
 use LizardsAndPumpkins\Context\ContextPartBuilder;
 use LizardsAndPumpkins\Context\ContextSource;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\Import\FileStorage\FileStorageReader;
 use LizardsAndPumpkins\Import\FileStorage\FileStorageWriter;
 use LizardsAndPumpkins\Import\Tax\TaxableCountries;
@@ -354,6 +355,11 @@ class UnitTestFactory implements Factory, MessageQueueFactory
     public function createApiRouter() : ApiRouter
     {
         return $this->createMock(ApiRouter::class);
+    }
+
+    public function createUrlToWebsiteMap(): UrlToWebsiteMap
+    {
+        return $this->createMock(UrlToWebsiteMap::class);
     }
 
     public function getMaxAllowedProductsPerSearchResultsPage() : int


### PR DESCRIPTION
Please refer to #1053 for details on the issue.

The setting of the `SCRIPT_NAME` server variable in the nginx configuration is no longer required with these code changes, as the request path without website prefix is determined based on the `LP_BASE_URL_TO_WEBSITE_MAP` [environment variable](https://github.com/lizards-and-pumpkins/dev-vm/blob/master/provisioning/sample/demo.lizardsandpumpkins.com.loc#L63).

Closes #1053 