### PR TITLE
Issue #1055: CatalogImportApiTest::getNextMessageFromQueue is an endl…

### DIFF
--- a/tests/Integration/Util/Messaging/Queue/InMemoryQueue.php
+++ b/tests/Integration/Util/Messaging/Queue/InMemoryQueue.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+declare(ticks=1);
 
 namespace LizardsAndPumpkins\Messaging\Queue;
 
@@ -53,6 +54,7 @@ class InMemoryQueue implements Queue, Clearable
                 $messageReceiver->receive($this->next());
                 $numberOfMessagesToConsumeBeforeReturn--;
             }
+            usleep(1);
         }
     }
 }


### PR DESCRIPTION
…ess loop

If the tests doesn't stop, one doesn't know what the problem is, now we
have a helpful error message

Fixes #1055 

To test this comment out the body of \LizardsAndPumpkins\Messaging\Queue\InMemoryQueue::add