### PR TITLE
Issue #1060: Add AssetsBaseUrlBuilder extension point

### DIFF
--- a/src/Import/TemplateRendering/Block.php
+++ b/src/Import/TemplateRendering/Block.php
@@ -44,17 +44,22 @@ class Block
         $this->dataObject = $dataObject;
     }
 
-    public function getBlockName() : string
+    public function getBlockName(): string
     {
         return $this->blockName;
     }
 
-    public function getBaseUrl() : BaseUrl
+    public function getBaseUrl(): BaseUrl
     {
         return $this->blockRenderer->getBaseUrl();
     }
 
-    public function getWebsiteCode() : string
+    public function getAssetsBaseUrl(): BaseUrl
+    {
+        return $this->blockRenderer->getAssetsBaseUrl();
+    }
+
+    public function getWebsiteCode(): string
     {
         return $this->blockRenderer->getWebsiteCode();
     }
@@ -67,16 +72,16 @@ class Block
         return $this->dataObject;
     }
 
-    final public function getLayoutHandle() : string
+    final public function getLayoutHandle(): string
     {
         return $this->blockRenderer->getLayoutHandle();
     }
 
-    final public function render() : string
+    final public function render(): string
     {
         $templatePath = realpath($this->template);
 
-        if (false === $templatePath || !is_readable($templatePath) || is_dir($templatePath)) {
+        if (false === $templatePath || ! is_readable($templatePath) || is_dir($templatePath)) {
             throw new TemplateFileNotReadableException(sprintf('Template "%s" is not readable.', $this->template));
         }
 
@@ -87,12 +92,12 @@ class Block
         return ob_get_clean();
     }
 
-    final public function getChildOutput(string $childName) : string
+    final public function getChildOutput(string $childName): string
     {
         return $this->blockRenderer->getChildBlockOutput($this->blockName, $childName);
     }
 
-    public function __(string $string) : string
+    public function __(string $string): string
     {
         return $this->blockRenderer->translate($string);
     }

--- a/src/Import/TemplateRendering/BlockRenderer.php
+++ b/src/Import/TemplateRendering/BlockRenderer.php
@@ -35,7 +35,7 @@ abstract class BlockRenderer
      * @var string[]
      */
     private $missingBlockNames;
-    
+
     /**
      * @var BlockStructure
      */
@@ -50,32 +50,39 @@ abstract class BlockRenderer
      * @var Block
      */
     private $outermostBlock;
-    
+
     /**
      * @var BaseUrlBuilder
      */
     private $baseUrlBuilder;
 
+    /**
+     * @var BaseUrlBuilder
+     */
+    private $assetsBaseUrlBuilder;
+
     public function __construct(
         ThemeLocator $themeLocator,
         BlockStructure $blockStructure,
         TranslatorRegistry $translatorRegistry,
-        BaseUrlBuilder $baseUrlBuilder
+        BaseUrlBuilder $baseUrlBuilder,
+        BaseUrlBuilder $assetsBaseUrlBuilder
     ) {
         $this->themeLocator = $themeLocator;
         $this->blockStructure = $blockStructure;
         $this->translatorRegistry = $translatorRegistry;
         $this->baseUrlBuilder = $baseUrlBuilder;
+        $this->assetsBaseUrlBuilder = $assetsBaseUrlBuilder;
     }
 
-    abstract public function getLayoutHandle() : string;
+    abstract public function getLayoutHandle(): string;
 
     /**
      * @param mixed $dataObject
      * @param Context $context
      * @return string
      */
-    public function render($dataObject, Context $context) : string
+    public function render($dataObject, Context $context): string
     {
         $this->dataObject = $dataObject;
         $this->context = $context;
@@ -95,12 +102,12 @@ abstract class BlockRenderer
         return $this->dataObject;
     }
 
-    private function getOuterMostBlockLayout() : Layout
+    private function getOuterMostBlockLayout(): Layout
     {
         $layout = $this->getLayout();
         $rootBlocks = $layout->getNodeChildren();
 
-        if (!is_array($rootBlocks) || 1 !== count($rootBlocks)) {
+        if (! is_array($rootBlocks) || 1 !== count($rootBlocks)) {
             throw new BlockRendererMustHaveOneRootBlockException(sprintf(
                 'Exactly one root block must be assigned to BlockRenderer "%s"',
                 $this->getLayoutHandle()
@@ -110,7 +117,7 @@ abstract class BlockRenderer
         return $rootBlocks[0];
     }
 
-    private function createBlockWithChildrenRecursively(Layout $layout) : Block
+    private function createBlockWithChildrenRecursively(Layout $layout): Block
     {
         $blockClass = $layout->getAttribute('class');
         $this->validateBlockClass($blockClass);
@@ -143,32 +150,34 @@ abstract class BlockRenderer
             throw new CanNotInstantiateBlockException('Block class is not specified.');
         }
 
-        if (!class_exists($blockClass)) {
+        if (! class_exists($blockClass)) {
             throw new CanNotInstantiateBlockException(sprintf('Block class does not exist "%s".', $blockClass));
         }
 
-        if (Block::class !== $blockClass && !in_array(Block::class, class_parents($blockClass))) {
+        if (Block::class !== $blockClass && ! in_array(Block::class, class_parents($blockClass))) {
             $message = sprintf('Block class "%s" must extend "%s"', $blockClass, Block::class);
             throw new CanNotInstantiateBlockException(sprintf($message));
         }
     }
 
-    private function getLayout() : Layout
+    private function getLayout(): Layout
     {
         return $this->themeLocator->getLayoutForHandle($this->getLayoutHandle());
     }
 
-    public function getChildBlockOutput(string $parentName, string $childName) : string
+    public function getChildBlockOutput(string $parentName, string $childName): string
     {
-        if (!$this->blockStructure->hasChildBlock($parentName, $childName)) {
+        if (! $this->blockStructure->hasChildBlock($parentName, $childName)) {
             $placeholder = $this->getBlockPlaceholder($childName);
             $this->missingBlockNames[] = $childName;
+
             return $placeholder;
         }
+
         return $this->blockStructure->getBlock($childName)->render();
     }
 
-    public function getRootSnippetCode() : string
+    public function getRootSnippetCode(): string
     {
         return $this->getLayoutHandle();
     }
@@ -176,33 +185,40 @@ abstract class BlockRenderer
     /**
      * @return string[]
      */
-    public function getNestedSnippetCodes() : array
+    public function getNestedSnippetCodes(): array
     {
         if (is_null($this->missingBlockNames)) {
             throw new MethodNotYetAvailableException(
                 'The method "getNestedSnippetCodes()" can not be called before "render()" is executed'
             );
         }
+
         return $this->missingBlockNames;
     }
 
-    public function translate(string $string) : string
+    public function translate(string $string): string
     {
         $locale = $this->context->getValue(Locale::CONTEXT_CODE);
+
         return $this->translatorRegistry->getTranslator($this->getLayoutHandle(), $locale)->translate($string);
     }
 
-    public function getBaseUrl() : BaseUrl
+    public function getBaseUrl(): BaseUrl
     {
         return $this->baseUrlBuilder->create($this->context);
     }
 
-    public function getWebsiteCode() : string
+    public function getAssetsBaseUrl(): BaseUrl
+    {
+        return $this->assetsBaseUrlBuilder->create($this->context);
+    }
+
+    public function getWebsiteCode(): string
     {
         return $this->context->getValue(Website::CONTEXT_CODE);
     }
 
-    private function getBlockPlaceholder(string $blockName) : string
+    private function getBlockPlaceholder(string $blockName): string
     {
         // TODO use delegate to generate the placeholder string
         // @see \LizardsAndPumpkins\UrlKeyRequestHandler::buildPlaceholdersFromCodes()

--- a/src/Util/Factory/CommonFactory.php
+++ b/src/Util/Factory/CommonFactory.php
@@ -377,7 +377,8 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
             $this->getMasterFactory()->getThemeLocator(),
             $this->getMasterFactory()->createBlockStructure(),
             $this->getMasterFactory()->getTranslatorRegistry(),
-            $this->getMasterFactory()->createBaseUrlBuilder()
+            $this->getMasterFactory()->createBaseUrlBuilder(),
+            $this->getMasterFactory()->createAssetsBaseUrlBuilder()
         );
     }
 
@@ -480,7 +481,8 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
             $this->getMasterFactory()->getThemeLocator(),
             $this->getMasterFactory()->createBlockStructure(),
             $this->getMasterFactory()->getTranslatorRegistry(),
-            $this->getMasterFactory()->createBaseUrlBuilder()
+            $this->getMasterFactory()->createBaseUrlBuilder(),
+            $this->getMasterFactory()->createAssetsBaseUrlBuilder()
         );
     }
 
@@ -1126,6 +1128,11 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
         return new WebsiteBaseUrlBuilder($this->getMasterFactory()->createConfigReader());
     }
 
+    public function createAssetsBaseUrlBuilder() : BaseUrlBuilder
+    {
+        return new WebsiteBaseUrlBuilder($this->getMasterFactory()->createConfigReader());
+    }
+
     public function getFacetFieldTransformationRegistry() : FacetFieldTransformationRegistry
     {
         if (null === $this->memoizedFacetFieldTransformationRegistry) {
@@ -1236,7 +1243,8 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
             $this->getMasterFactory()->getThemeLocator(),
             $this->getMasterFactory()->createBlockStructure(),
             $this->getMasterFactory()->getTranslatorRegistry(),
-            $this->getMasterFactory()->createBaseUrlBuilder()
+            $this->getMasterFactory()->createBaseUrlBuilder(),
+            $this->getMasterFactory()->createAssetsBaseUrlBuilder()
         );
     }
 

--- a/tests/Integration/Util/IntegrationTestFactory.php
+++ b/tests/Integration/Util/IntegrationTestFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins;
 
+use LizardsAndPumpkins\Context\BaseUrl\BaseUrlBuilder;
 use LizardsAndPumpkins\Context\BaseUrl\IntegrationTestFixedBaseUrlBuilder;
 use LizardsAndPumpkins\Context\ContextPartBuilder;
 use LizardsAndPumpkins\Context\ContextSource;
@@ -285,7 +286,12 @@ class IntegrationTestFactory implements Factory, MessageQueueFactory
         return new LocalFilesystemStorageWriter();
     }
 
-    public function createBaseUrlBuilder() : IntegrationTestFixedBaseUrlBuilder
+    public function createBaseUrlBuilder() : BaseUrlBuilder
+    {
+        return new IntegrationTestFixedBaseUrlBuilder();
+    }
+
+    public function createAssetsBaseUrlBuilder() : BaseUrlBuilder
     {
         return new IntegrationTestFixedBaseUrlBuilder();
     }

--- a/tests/Unit/Suites/Import/TemplateRendering/AbstractBlockRendererTest.php
+++ b/tests/Unit/Suites/Import/TemplateRendering/AbstractBlockRendererTest.php
@@ -46,6 +46,11 @@ abstract class AbstractBlockRendererTest extends TestCase
     private $mockBaseUrlBuilder;
 
     /**
+     * @var BaseUrlBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockAssetsBaseUrlBuilder;
+
+    /**
      * @return Layout|\PHPUnit_Framework_MockObject_MockObject
      */
     final protected function getStubLayout()
@@ -80,6 +85,14 @@ abstract class AbstractBlockRendererTest extends TestCase
     final protected function getMockBaseUrlBuilder()
     {
         return $this->mockBaseUrlBuilder;
+    }
+
+    /**
+     * @return BaseUrlBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    final protected function getMockAssetsBaseUrlBuilder()
+    {
+        return $this->mockAssetsBaseUrlBuilder;
     }
 
     /**
@@ -133,7 +146,8 @@ abstract class AbstractBlockRendererTest extends TestCase
         ThemeLocator $stubThemeLocator,
         BlockStructure $stubBlockStructure,
         TranslatorRegistry $stubTranslatorRegistry,
-        BaseUrlBuilder $baseUrlBuilder
+        BaseUrlBuilder $baseUrlBuilder,
+        BaseUrlBuilder $assetsBaseUrlBuilder
     ) : BlockRenderer;
 
     protected function setUp()
@@ -147,6 +161,7 @@ abstract class AbstractBlockRendererTest extends TestCase
         $this->stubTranslator = $this->createMock(Translator::class);
         
         $this->mockBaseUrlBuilder = $this->createMock(BaseUrlBuilder::class);
+        $this->mockAssetsBaseUrlBuilder = $this->createMock(BaseUrlBuilder::class);
 
         /** @var TranslatorRegistry|\PHPUnit_Framework_MockObject_MockObject $stubTranslatorRegistry */
         $stubTranslatorRegistry = $this->createMock(TranslatorRegistry::class);
@@ -156,7 +171,8 @@ abstract class AbstractBlockRendererTest extends TestCase
             $this->stubThemeLocator,
             $this->stubBlockStructure,
             $stubTranslatorRegistry,
-            $this->mockBaseUrlBuilder
+            $this->mockBaseUrlBuilder,
+            $this->mockAssetsBaseUrlBuilder
         );
     }
 

--- a/tests/Unit/Suites/Import/TemplateRendering/BlockRendererTest.php
+++ b/tests/Unit/Suites/Import/TemplateRendering/BlockRendererTest.php
@@ -24,9 +24,16 @@ class BlockRendererTest extends AbstractBlockRendererTest
         ThemeLocator $stubThemeLocator,
         BlockStructure $stubBlockStructure,
         TranslatorRegistry $stubTranslatorRegistry,
-        BaseUrlBuilder $baseUrlBuilder
-    ) : BlockRenderer {
-        return new StubBlockRenderer($stubThemeLocator, $stubBlockStructure, $stubTranslatorRegistry, $baseUrlBuilder);
+        BaseUrlBuilder $baseUrlBuilder,
+        BaseUrlBuilder $stubAssetsBaseUrlBuilder
+    ): BlockRenderer {
+        return new StubBlockRenderer(
+            $stubThemeLocator,
+            $stubBlockStructure,
+            $stubTranslatorRegistry,
+            $baseUrlBuilder,
+            $stubAssetsBaseUrlBuilder
+        );
     }
 
     public function testExceptionIsThrownIfNoRootBlockIsDefined()
@@ -160,7 +167,7 @@ class BlockRendererTest extends AbstractBlockRendererTest
 
         $this->getBlockRenderer()->render('test-projection-source-data', $this->getStubContext());
         $this->assertEquals([$childBlockName1, $childBlockName2], $this->getBlockRenderer()->getNestedSnippetCodes());
-        
+
         $this->getBlockRenderer()->render('test-projection-source-data', $this->getStubContext());
         $this->assertEquals([$childBlockName1, $childBlockName2], $this->getBlockRenderer()->getNestedSnippetCodes());
     }
@@ -205,10 +212,10 @@ class BlockRendererTest extends AbstractBlockRendererTest
         $this->createFixtureFile($testDir . '/test-template.php', 'test template content');
         $this->addStubRootBlock(StubBlock::class, $testDir . '/test-template.php');
         $this->getBlockRenderer()->render('test-projection-source-data', $this->getStubContext());
-        
+
         $this->getBlockRenderer()->getBaseUrl();
     }
-    
+
     public function testWebsiteCodeIsReturned()
     {
         $testWebsiteCode = 'foo';
@@ -224,5 +231,18 @@ class BlockRendererTest extends AbstractBlockRendererTest
         $this->getBlockRenderer()->render($dataObject, $stubContext);
 
         $this->assertSame($testWebsiteCode, $this->getBlockRenderer()->getWebsiteCode());
+    }
+
+    public function testDelegatesGettingTheAssetBaseUrlToTheAssetsBaseUrlBuilder()
+    {
+        $this->getMockAssetsBaseUrlBuilder()->expects($this->once())->method('create')->with($this->getStubContext());
+
+        $testDir = $this->getUniqueTempDir();
+        $this->createFixtureDirectory($testDir);
+        $this->createFixtureFile($testDir . '/test-template.php', 'test template content');
+        $this->addStubRootBlock(StubBlock::class, $testDir . '/test-template.php');
+        $this->getBlockRenderer()->render('test-projection-source-data', $this->getStubContext());
+
+        $this->getBlockRenderer()->getAssetsBaseUrl();
     }
 }

--- a/tests/Unit/Suites/Import/TemplateRendering/BlockTest.php
+++ b/tests/Unit/Suites/Import/TemplateRendering/BlockTest.php
@@ -117,10 +117,17 @@ class BlockTest extends TestCase
 
     public function testItDelegatesFetchingTheBaseUrlToTheBlockRenderer()
     {
-        $dummyBaseUrl = new HttpBaseUrl('http://example.com/');
-        $this->mockBlockRenderer->expects($this->once())->method('getBaseUrl')->willReturn($dummyBaseUrl);
+        $baseUrl = new HttpBaseUrl('http://example.com/');
+        $this->mockBlockRenderer->expects($this->once())->method('getBaseUrl')->willReturn($baseUrl);
         
-        $this->assertSame($dummyBaseUrl, $this->block->getBaseUrl());
+        $this->assertSame($baseUrl, $this->block->getBaseUrl());
+    }
+
+    public function testDelegatesFetchingTheAssetsBaseUrlToTheBlockRenderer()
+    {
+        $assetsBaseUrl = new HttpBaseUrl('http://example.com/');
+        $this->mockBlockRenderer->expects($this->once())->method('getAssetsBaseUrl')->willReturn($assetsBaseUrl);
+        $this->assertSame($assetsBaseUrl, $this->block->getAssetsBaseUrl());
     }
 
     public function testFetchingWebsiteCodeIsDelegatedToBlockRenderer()

--- a/tests/Unit/Suites/ProductDetail/TemplateRendering/ProductDetailViewBlockRendererTest.php
+++ b/tests/Unit/Suites/ProductDetail/TemplateRendering/ProductDetailViewBlockRendererTest.php
@@ -23,13 +23,15 @@ class ProductDetailViewBlockRendererTest extends AbstractBlockRendererTest
         ThemeLocator $stubThemeLocator,
         BlockStructure $stubBlockStructure,
         TranslatorRegistry $stubTranslatorRegistry,
-        BaseUrlBuilder $stubBaseUrlBuilder
+        BaseUrlBuilder $stubBaseUrlBuilder,
+        BaseUrlBuilder $stubAssetsBaseUrlBuilder
     ) : BlockRenderer {
         return new ProductDetailViewBlockRenderer(
             $stubThemeLocator,
             $stubBlockStructure,
             $stubTranslatorRegistry,
-            $stubBaseUrlBuilder
+            $stubBaseUrlBuilder,
+            $stubAssetsBaseUrlBuilder
         );
     }
 }

--- a/tests/Unit/Suites/ProductListing/Import/TemplateRendering/ProductListingBlockRendererTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/TemplateRendering/ProductListingBlockRendererTest.php
@@ -21,13 +21,15 @@ class ProductListingBlockRendererTest extends AbstractBlockRendererTest
         ThemeLocator $stubThemeLocator,
         BlockStructure $stubBlockStructure,
         TranslatorRegistry $stubTranslatorRegistry,
-        BaseUrlBuilder $baseUrlBuilder
+        BaseUrlBuilder $baseUrlBuilder,
+        BaseUrlBuilder $assetsBaseUrlBuilder
     ) : BlockRenderer {
         return new ProductListingBlockRenderer(
             $stubThemeLocator,
             $stubBlockStructure,
             $stubTranslatorRegistry,
-            $baseUrlBuilder
+            $baseUrlBuilder, 
+            $assetsBaseUrlBuilder
         );
     }
 }

--- a/tests/Unit/Suites/ProductListing/Import/TemplateRendering/ProductListingDescriptionBlockRendererTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/TemplateRendering/ProductListingDescriptionBlockRendererTest.php
@@ -21,13 +21,15 @@ class ProductListingDescriptionBlockRendererTest extends AbstractBlockRendererTe
         ThemeLocator $stubThemeLocator,
         BlockStructure $stubBlockStructure,
         TranslatorRegistry $stubTranslatorRegistry,
-        BaseUrlBuilder $baseUrlBuilder
+        BaseUrlBuilder $baseUrlBuilder,
+        BaseUrlBuilder $assetsBaseUrlBuilder
     ) : BlockRenderer {
         return new ProductListingDescriptionBlockRenderer(
             $stubThemeLocator,
             $stubBlockStructure,
             $stubTranslatorRegistry,
-            $baseUrlBuilder
+            $baseUrlBuilder,
+            $assetsBaseUrlBuilder
         );
     }
 }

--- a/tests/Unit/Util/UnitTestFactory.php
+++ b/tests/Unit/Util/UnitTestFactory.php
@@ -164,6 +164,11 @@ class UnitTestFactory implements Factory, MessageQueueFactory
         return $this->createMock(BaseUrlBuilder::class);
     }
 
+    public function createAssetsBaseUrlBuilder() : BaseUrlBuilder
+    {
+        return $this->createMock(BaseUrlBuilder::class);
+    }
+
     public function createImageProcessingStrategySequence() : ImageProcessingStrategy
     {
         return $this->createMock(ImageProcessingStrategy::class);


### PR DESCRIPTION
Once this is merged, refactor the sample project templates to use `$this->getAssetsBaseUrl()` where appropriate.

Closes #1060