### PR TITLE
Issue #261: Extract product detail view root snippet

### DIFF
--- a/src/Http/ContentDelivery/FrontendFactory.php
+++ b/src/Http/ContentDelivery/FrontendFactory.php
@@ -7,6 +7,7 @@ namespace LizardsAndPumpkins\Http\ContentDelivery;
 use LizardsAndPumpkins\Http\ContentDelivery\PageBuilder\PageBuilder;
 use LizardsAndPumpkins\Http\Routing\HttpRequestHandler;
 use LizardsAndPumpkins\Http\Routing\UnknownHttpRequestMethodHandler;
+use LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer;
 use LizardsAndPumpkins\ProductDetail\ProductDetailViewRequestHandler;
 use LizardsAndPumpkins\ProductListing\ContentDelivery\ProductListingPageContentBuilder;
 use LizardsAndPumpkins\ProductListing\ContentDelivery\ProductListingPageRequest;
@@ -23,7 +24,7 @@ use LizardsAndPumpkins\Http\HttpRequest;
 use LizardsAndPumpkins\Http\Routing\HttpRouter;
 use LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRenderer;
 use LizardsAndPumpkins\Import\Price\PriceSnippetRenderer;
-use LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer;
+use LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer;
 use LizardsAndPumpkins\Import\Product\ProductJsonSnippetRenderer;
 use LizardsAndPumpkins\ProductListing\Import\ProductListingSnippetRenderer;
 use LizardsAndPumpkins\ProductListing\Import\ProductListingTemplateSnippetRenderer;
@@ -144,9 +145,15 @@ class FrontendFactory implements Factory
     {
         $registrySnippetKeyGeneratorLocator = new RegistrySnippetKeyGeneratorLocatorStrategy;
         $registrySnippetKeyGeneratorLocator->register(
-            ProductDetailViewSnippetRenderer::CODE,
+            ProductDetailMetaSnippetRenderer::CODE,
             function () {
-                return $this->getMasterFactory()->createProductDetailViewSnippetKeyGenerator();
+                return $this->getMasterFactory()->createProductDetailPageMetaSnippetKeyGenerator();
+            }
+        );
+        $registrySnippetKeyGeneratorLocator->register(
+            ProductDetailTemplateSnippetRenderer::CODE,
+            function () {
+                return $this->getMasterFactory()->createProductDetailTemplateSnippetKeyGenerator();
             }
         );
         $registrySnippetKeyGeneratorLocator->register(

--- a/src/Import/Product/View/IntegrationTestConfigurableProductView.php
+++ b/src/Import/Product/View/IntegrationTestConfigurableProductView.php
@@ -48,9 +48,4 @@ class IntegrationTestConfigurableProductView extends AbstractConfigurableProduct
     {
         return $this->productImageFileLocator;
     }
-
-    public function getProductPageTitle() : string
-    {
-        return $this->getFirstValueOfAttribute('name');
-    }
 }

--- a/src/Import/Product/View/IntegrationTestProductView.php
+++ b/src/Import/Product/View/IntegrationTestProductView.php
@@ -33,9 +33,4 @@ class IntegrationTestProductView extends AbstractProductView
     {
         return $this->productImageFileLocator;
     }
-
-    public function getProductPageTitle() : string
-    {
-        return $this->getFirstValueOfAttribute('name');
-    }
 }

--- a/src/Import/Product/View/ProductView.php
+++ b/src/Import/Product/View/ProductView.php
@@ -53,6 +53,4 @@ interface ProductView extends \JsonSerializable
     public function getMainImageUrl(string $variation) : HttpUrl;
 
     public function getMainImageLabel() : string;
-
-    public function getProductPageTitle() : string;
 }

--- a/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
+++ b/src/Import/RootTemplate/TemplateWasUpdatedDomainEventHandler.php
@@ -5,9 +5,9 @@ declare(strict_types = 1);
 namespace LizardsAndPumpkins\Import\RootTemplate;
 
 use LizardsAndPumpkins\Import\RootTemplate\Import\TemplateProjectorLocator;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
 use LizardsAndPumpkins\Messaging\Event\DomainEventHandler;
 use LizardsAndPumpkins\Messaging\Queue\Message;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 class TemplateWasUpdatedDomainEventHandler implements DomainEventHandler
 {

--- a/src/Import/TemplateRendering/TemplateProjectionData.php
+++ b/src/Import/TemplateRendering/TemplateProjectionData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace LizardsAndPumpkins\ProductListing\Import\TemplateRendering;
+namespace LizardsAndPumpkins\Import\TemplateRendering;
 
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent;

--- a/src/Import/TemplateRendering/TemplateSnippetRenderer.php
+++ b/src/Import/TemplateRendering/TemplateSnippetRenderer.php
@@ -10,7 +10,6 @@ use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\Import\Exception\InvalidDataObjectTypeException;
 use LizardsAndPumpkins\Import\SnippetRenderer;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 class TemplateSnippetRenderer implements SnippetRenderer
 {

--- a/src/ProductDetail/Import/ProductDetailTemplateSnippetRenderer.php
+++ b/src/ProductDetail/Import/ProductDetailTemplateSnippetRenderer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LizardsAndPumpkins\ProductDetail\Import;
+
+use LizardsAndPumpkins\Import\SnippetRenderer;
+use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateSnippetRenderer;
+
+class ProductDetailTemplateSnippetRenderer implements SnippetRenderer
+{
+    const CODE = 'product_detail_view';
+
+    /**
+     * @var TemplateSnippetRenderer
+     */
+    private $templateSnippetRenderer;
+
+    public function __construct(TemplateSnippetRenderer $templateSnippetRenderer)
+    {
+        $this->templateSnippetRenderer = $templateSnippetRenderer;
+    }
+
+    /**
+     * @param TemplateProjectionData $dataToRender
+     * @return Snippet[]
+     */
+    public function render($dataToRender): array
+    {
+        return $this->templateSnippetRenderer->render($dataToRender);
+    }
+}

--- a/src/ProductDetail/ProductDetailViewRequestHandler.php
+++ b/src/ProductDetail/ProductDetailViewRequestHandler.php
@@ -16,6 +16,7 @@ use LizardsAndPumpkins\Http\HttpResponse;
 use LizardsAndPumpkins\Http\Routing\Exception\UnableToHandleRequestException;
 use LizardsAndPumpkins\Import\PageMetaInfoSnippetContent;
 use LizardsAndPumpkins\Import\Product\Product;
+use LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer;
 use LizardsAndPumpkins\Translation\TranslatorRegistry;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 
@@ -137,7 +138,7 @@ class ProductDetailViewRequestHandler implements HttpRequestHandler
     private function addTranslationsToPageBuilder(Context $context)
     {
         $translator = $this->translatorRegistry->getTranslator(
-            ProductDetailMetaSnippetRenderer::CODE,
+            ProductDetailTemplateSnippetRenderer::CODE,
             $context->getValue(Locale::CONTEXT_CODE)
         );
         $this->addDynamicSnippetToPageBuilder('translations', json_encode($translator));

--- a/src/ProductDetail/ProductDetailViewRequestHandler.php
+++ b/src/ProductDetail/ProductDetailViewRequestHandler.php
@@ -89,10 +89,7 @@ class ProductDetailViewRequestHandler implements HttpRequestHandler
             throw new UnableToHandleRequestException(sprintf('Unable to handle request to "%s"', $request->getUrl()));
         }
 
-        $keyGeneratorParams = [
-            Product::ID => $this->pageMetaInfo->getProductId(),
-            'robots' => 'all'
-        ];
+        $keyGeneratorParams = [Product::ID => $this->pageMetaInfo->getProductId()];
 
         $this->addTranslationsToPageBuilder($this->context);
 
@@ -140,7 +137,7 @@ class ProductDetailViewRequestHandler implements HttpRequestHandler
     private function addTranslationsToPageBuilder(Context $context)
     {
         $translator = $this->translatorRegistry->getTranslator(
-            ProductDetailViewSnippetRenderer::CODE,
+            ProductDetailMetaSnippetRenderer::CODE,
             $context->getValue(Locale::CONTEXT_CODE)
         );
         $this->addDynamicSnippetToPageBuilder('translations', json_encode($translator));

--- a/src/ProductListing/ContentDelivery/ProductSearchRequestHandler.php
+++ b/src/ProductListing/ContentDelivery/ProductSearchRequestHandler.php
@@ -127,14 +127,11 @@ class ProductSearchRequestHandler implements HttpRequestHandler
         $productSearchResult = $this->getSearchResults($request, $productsPerPage, $selectedSortBy);
 
         $metaInfoSnippetContent = $this->getPageMetaInfo();
-        $keyGeneratorParams = [
-            'robots' => 'noindex',
-        ];
 
         return $this->productListingPageContentBuilder->buildPageContent(
             $metaInfoSnippetContent,
             $this->context,
-            $keyGeneratorParams,
+            $keyGeneratorParams = [],
             $productSearchResult,
             $productsPerPage,
             $selectedSortBy,

--- a/src/ProductListing/Import/ProductListingTemplateSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductListingTemplateSnippetRenderer.php
@@ -6,8 +6,8 @@ namespace LizardsAndPumpkins\ProductListing\Import;
 
 use LizardsAndPumpkins\Import\SnippetRenderer;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
 use LizardsAndPumpkins\Import\TemplateRendering\TemplateSnippetRenderer;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 class ProductListingTemplateSnippetRenderer implements SnippetRenderer
 {

--- a/src/ProductListing/Import/ProductSearchResultMetaSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductSearchResultMetaSnippetRenderer.php
@@ -10,8 +10,8 @@ use LizardsAndPumpkins\Import\TemplateRendering\BlockRenderer;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\Import\SnippetRenderer;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
 use LizardsAndPumpkins\ProductListing\ContentDelivery\ProductSearchResultMetaSnippetContent;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 
 class ProductSearchResultMetaSnippetRenderer implements SnippetRenderer
 {

--- a/src/Util/Factory/CatalogMasterFactory.php
+++ b/src/Util/Factory/CatalogMasterFactory.php
@@ -7,10 +7,10 @@ namespace LizardsAndPumpkins\Util\Factory;
 use LizardsAndPumpkins\Context\Context;
 use LizardsAndPumpkins\Context\ContextBuilder;
 use LizardsAndPumpkins\Context\ContextSource;
+use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\DataPoolReader;
 use LizardsAndPumpkins\DataPool\DataPoolWriter;
 use LizardsAndPumpkins\DataPool\KeyGenerator\GenericSnippetKeyGenerator;
-use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGeneratorLocator;
 use LizardsAndPumpkins\DataPool\SearchEngine\FacetFiltersToIncludeInResult;
 use LizardsAndPumpkins\DataPool\SearchEngine\Query\SortBy;
@@ -45,7 +45,6 @@ use LizardsAndPumpkins\Translation\TranslatorRegistry;
  * @method RegistrySnippetKeyGeneratorLocatorStrategy createRegistrySnippetKeyGeneratorLocatorStrategy
  * @method SnippetKeyGeneratorLocator getSnippetKeyGeneratorLocator
  * @method InMemoryLogger getLogger
- * @method GenericSnippetKeyGenerator createProductDetailViewSnippetKeyGenerator
  * @method GenericSnippetKeyGenerator createProductListingSnippetKeyGenerator
  * @method GenericSnippetKeyGenerator createProductStockQuantityRendererSnippetKeyGenerator
  * @method ContentBlockSnippetKeyGeneratorLocatorStrategy createContentBlockSnippetKeyGeneratorLocatorStrategy
@@ -66,7 +65,7 @@ use LizardsAndPumpkins\Translation\TranslatorRegistry;
  * @method SearchEngine getSearchEngine
  * @method callable getProductDetailsViewTranslatorFactory
  * @method TranslatorRegistry getTranslatorRegistry
- * @method SnippetKeyGenerator createProductListingTitleSnippetKeyGenerator
+ * @method UrlToWebsiteMap createUrlToWebsiteMap
  */
 class CatalogMasterFactory implements MasterFactory
 {

--- a/src/Util/Factory/CommonFactory.php
+++ b/src/Util/Factory/CommonFactory.php
@@ -1041,7 +1041,7 @@ class CommonFactory implements Factory, DomainEventHandlerFactory, CommandHandle
             );
 
             $this->translatorRegistry->register(
-                ProductDetailMetaSnippetRenderer::CODE,
+                ProductDetailTemplateSnippetRenderer::CODE,
                 $this->getMasterFactory()->getProductDetailsViewTranslatorFactory()
             );
         }

--- a/tests/Integration/Suites/FrontendRenderingTest.php
+++ b/tests/Integration/Suites/FrontendRenderingTest.php
@@ -7,7 +7,6 @@ namespace LizardsAndPumpkins;
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Context\Locale\Locale;
 use LizardsAndPumpkins\Context\Website\IntegrationTestUrlToWebsiteMap;
-use LizardsAndPumpkins\Context\Website\UrlToWebsiteMap;
 use LizardsAndPumpkins\DataPool\KeyGenerator\GenericSnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
@@ -24,7 +23,7 @@ use LizardsAndPumpkins\Logging\Logger;
 use LizardsAndPumpkins\Import\Price\PriceSnippetRenderer;
 use LizardsAndPumpkins\Import\Product\Product;
 use LizardsAndPumpkins\ProductDetail\ProductDetailPageMetaInfoSnippetContent;
-use LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer;
+use LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer;
 use LizardsAndPumpkins\Import\Product\ProductJsonSnippetRenderer;
 use LizardsAndPumpkins\DataPool\KeyGenerator\RegistrySnippetKeyGeneratorLocatorStrategy;
 use LizardsAndPumpkins\Util\Factory\CatalogMasterFactory;
@@ -74,7 +73,7 @@ class FrontendRenderingTest extends AbstractIntegrationTest
     private function registerSnippetKeyGenerators(string $rootSnippetCode)
     {
         $rootSnippetKeyGenerator = new GenericSnippetKeyGenerator(
-            ProductDetailViewSnippetRenderer::CODE,
+            ProductDetailMetaSnippetRenderer::CODE,
             $this->factory->getRequiredContextParts(),
             [Product::ID]
         );
@@ -163,7 +162,6 @@ class FrontendRenderingTest extends AbstractIntegrationTest
             Locale::CONTEXT_CODE => 'foo_BAR'
         ]);
         
-        /** @var UrlToWebsiteMap $urlToWebsiteMap */
         $urlToWebsiteMap = $this->factory->createUrlToWebsiteMap();
         $metaSnippetKeyGenerator = $this->factory->createProductDetailPageMetaSnippetKeyGenerator();
         $pathWithoutWebsitePrefix = $urlToWebsiteMap->getRequestPathWithoutWebsitePrefix((string) $this->request->getUrl());

--- a/tests/Integration/fixture/theme/layout/product_detail_view.xml
+++ b/tests/Integration/fixture/theme/layout/product_detail_view.xml
@@ -3,6 +3,6 @@
         xsi:schemaLocation="http://lizardsandpumpkins.com ../../../../../schema/snippet.xsd">
     <block name="product_details_snippet" class="LizardsAndPumpkins\Import\TemplateRendering\Block" template="template/1column.phtml">
         <block name="head" class="LizardsAndPumpkins\Import\TemplateRendering\Block" template="template/head.phtml"/>
-        <block name="content" class="LizardsAndPumpkins\Import\TemplateRendering\Block\ProductBlock" template="template/product-details.phtml"/>
+        <block name="content" class="LizardsAndPumpkins\Import\TemplateRendering\Block" template="template/product-details.phtml"/>
     </block>
 </snippet>

--- a/tests/Integration/fixture/theme/template/product-details.phtml
+++ b/tests/Integration/fixture/theme/template/product-details.phtml
@@ -8,8 +8,6 @@ declare(strict_types=1);
 use LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRenderer;
 
 ?>
-<h1><?= $this->getFirstValueOfProductAttribute('name') ?></h1>
-<p><?= $this->getProductId() ?></p>
 
 <script type="text/javascript">
 

--- a/tests/Unit/Suites/ConsoleCommand/CliBootstrapTest.php
+++ b/tests/Unit/Suites/ConsoleCommand/CliBootstrapTest.php
@@ -62,7 +62,8 @@ use PHPUnit\Framework\TestCase;
  * @uses   \LizardsAndPumpkins\Messaging\Consumer\ShutdownWorkerDirectiveHandler
  * @uses   \LizardsAndPumpkins\Messaging\Queue\EnqueuesMessageEnvelope
  * @uses   \LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRenderer
- * @uses   \LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer
+ * @uses   \LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer
+ * @uses   \LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer
  * @uses   \LizardsAndPumpkins\ProductListing\AddProductListingCommandHandler
  * @uses   \LizardsAndPumpkins\ProductListing\Import\ProductListingContentBlockSnippetKeyGeneratorLocatorStrategy
  * @uses   \LizardsAndPumpkins\ProductListing\Import\ProductListingProjector

--- a/tests/Unit/Suites/ConsoleCommand/CliFactoryBootstrapTest.php
+++ b/tests/Unit/Suites/ConsoleCommand/CliFactoryBootstrapTest.php
@@ -60,7 +60,8 @@ use PHPUnit\Framework\TestCase;
  * @uses   \LizardsAndPumpkins\Messaging\Consumer\ShutdownWorkerDirectiveHandler
  * @uses   \LizardsAndPumpkins\Messaging\Queue\EnqueuesMessageEnvelope
  * @uses   \LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRenderer
- * @uses   \LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer
+ * @uses   \LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer
+ * @uses   \LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer
  * @uses   \LizardsAndPumpkins\ProductListing\AddProductListingCommandHandler
  * @uses   \LizardsAndPumpkins\ProductListing\Import\ProductListingContentBlockSnippetKeyGeneratorLocatorStrategy
  * @uses   \LizardsAndPumpkins\ProductListing\Import\ProductListingProjector

--- a/tests/Unit/Suites/Http/ContentDelivery/FrontendFactoryTest.php
+++ b/tests/Unit/Suites/Http/ContentDelivery/FrontendFactoryTest.php
@@ -20,7 +20,7 @@ use LizardsAndPumpkins\Import\Price\PriceSnippetRenderer;
 use LizardsAndPumpkins\Import\Product\ProductJsonSnippetRenderer;
 use LizardsAndPumpkins\ProductDetail\ContentDelivery\SimpleEuroPriceSnippetTransformation;
 use LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRenderer;
-use LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer;
+use LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer;
 use LizardsAndPumpkins\ProductListing\Import\ProductListingSnippetRenderer;
 use LizardsAndPumpkins\ProductListing\Import\ProductListingTemplateSnippetRenderer;
 use LizardsAndPumpkins\ProductListing\Import\ProductSearchResultMetaSnippetRenderer;
@@ -206,7 +206,7 @@ class FrontendFactoryTest extends TestCase
     public function registeredSnippetCodeDataProvider() : array
     {
         return [
-            [ProductDetailViewSnippetRenderer::CODE],
+            [ProductDetailMetaSnippetRenderer::CODE],
             [ProductInListingSnippetRenderer::CODE],
             [ProductListingTemplateSnippetRenderer::CODE],
             [PriceSnippetRenderer::PRICE],

--- a/tests/Unit/Suites/Import/Product/View/Stub/StubConfigurableProductView.php
+++ b/tests/Unit/Suites/Import/Product/View/Stub/StubConfigurableProductView.php
@@ -51,9 +51,4 @@ class StubConfigurableProductView extends AbstractConfigurableProductView
     {
         return $this->productViewLocator;
     }
-
-    public function getProductPageTitle() : string
-    {
-        return $this->getFirstValueOfAttribute('name');
-    }
 }

--- a/tests/Unit/Suites/Import/Product/View/Stub/StubProductView.php
+++ b/tests/Unit/Suites/Import/Product/View/Stub/StubProductView.php
@@ -35,9 +35,4 @@ class StubProductView extends AbstractProductView
     {
         return $this->imageFileLocator;
     }
-
-    public function getProductPageTitle() : string
-    {
-        return $this->getFirstValueOfAttribute('name');
-    }
 }

--- a/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
+++ b/tests/Unit/Suites/Import/RootTemplate/TemplateWasUpdatedDomainEventHandlerTest.php
@@ -7,20 +7,20 @@ namespace LizardsAndPumpkins\Import\RootTemplate;
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Import\Projector;
 use LizardsAndPumpkins\Import\RootTemplate\Import\TemplateProjectorLocator;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
 use LizardsAndPumpkins\Messaging\Event\DomainEventHandler;
 use LizardsAndPumpkins\Messaging\Queue\Message;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEventHandler
  * @uses   \LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent
+ * @uses   \LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData
  * @uses   \LizardsAndPumpkins\Messaging\Queue\Message
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageMetadata
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessageName
  * @uses   \LizardsAndPumpkins\Messaging\Queue\MessagePayload
  * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
- * @uses   \LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData
  */
 class TemplateWasUpdatedDomainEventHandlerTest extends TestCase
 {

--- a/tests/Unit/Suites/Import/TemplateRendering/TemplateProjectionDataTest.php
+++ b/tests/Unit/Suites/Import/TemplateRendering/TemplateProjectionDataTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types = 1);
 
-namespace LizardsAndPumpkins\ProductListing\Import\TemplateRendering;
+namespace LizardsAndPumpkins\Import\TemplateRendering;
 
 use LizardsAndPumpkins\Context\DataVersion\DataVersion;
 use LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData
+ * @covers \LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData
  * @uses   \LizardsAndPumpkins\Context\DataVersion\DataVersion
  * @uses   \LizardsAndPumpkins\Import\RootTemplate\TemplateWasUpdatedDomainEvent
  */

--- a/tests/Unit/Suites/Import/TemplateRendering/TemplateSnippetRendererTest.php
+++ b/tests/Unit/Suites/Import/TemplateRendering/TemplateSnippetRendererTest.php
@@ -10,7 +10,6 @@ use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
 use LizardsAndPumpkins\Import\Exception\InvalidDataObjectTypeException;
 use LizardsAndPumpkins\Import\SnippetRenderer;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/Suites/Logging/LoggingDomainEventHandlerFactoryTest.php
+++ b/tests/Unit/Suites/Logging/LoggingDomainEventHandlerFactoryTest.php
@@ -55,7 +55,8 @@ use PHPUnit\Framework\TestCase;
  * @uses \LizardsAndPumpkins\Messaging\Consumer\ShutdownWorkerDirectiveHandler
  * @uses \LizardsAndPumpkins\Messaging\Queue\EnqueuesMessageEnvelope
  * @uses \LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRenderer
- * @uses \LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer
+ * @uses \LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer
+ * @uses \LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer
  * @uses \LizardsAndPumpkins\ProductListing\Import\ProductListingContentBlockSnippetKeyGeneratorLocatorStrategy
  * @uses \LizardsAndPumpkins\ProductListing\Import\ProductListingProjector
  * @uses \LizardsAndPumpkins\ProductListing\Import\ProductListingSnippetRenderer

--- a/tests/Unit/Suites/ProductDetail/Import/ProductDetailTemplateSnippetRendererTest.php
+++ b/tests/Unit/Suites/ProductDetail/Import/ProductDetailTemplateSnippetRendererTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LizardsAndPumpkins\ProductDetail\Import;
+
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateSnippetRenderer;
+use LizardsAndPumpkins\Import\SnippetRenderer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer
+ * @uses   \LizardsAndPumpkins\DataPool\KeyValueStore\Snippet
+ */
+class ProductDetailTemplateSnippetRendererTest extends TestCase
+{
+    /**
+     * @var ProductDetailTemplateSnippetRenderer
+     */
+    private $renderer;
+
+    /**
+     * @var TemplateSnippetRenderer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockTemplateSnippetRenderer;
+
+    final protected function setUp()
+    {
+        $this->mockTemplateSnippetRenderer = $this->createMock(TemplateSnippetRenderer::class);
+        $this->renderer = new ProductDetailTemplateSnippetRenderer($this->mockTemplateSnippetRenderer);
+    }
+
+    public function testisSnippetRenderer()
+    {
+        $this->assertInstanceOf(SnippetRenderer::class, $this->renderer);
+    }
+
+    public function testDelegatesSnippetRenderingToTemplateSnippetRenderer()
+    {
+        /** @var TemplateProjectionData|\PHPUnit_Framework_MockObject_MockObject $dummyTemplateProjectionData */
+        $dummyTemplateProjectionData = $this->createMock(TemplateProjectionData::class);
+
+        $this->mockTemplateSnippetRenderer->expects($this->once())->method('render')
+            ->with($dummyTemplateProjectionData);
+
+        $this->renderer->render($dummyTemplateProjectionData);
+    }
+}

--- a/tests/Unit/Suites/ProductListing/Import/ProductListingTemplateSnippetRendererTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/ProductListingTemplateSnippetRendererTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\ProductListing\Import;
 
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
 use LizardsAndPumpkins\Import\TemplateRendering\TemplateSnippetRenderer;
 use LizardsAndPumpkins\Import\SnippetRenderer;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/Suites/ProductListing/Import/ProductSearchResultMetaSnippetRendererTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/ProductSearchResultMetaSnippetRendererTest.php
@@ -10,8 +10,8 @@ use LizardsAndPumpkins\DataPool\KeyGenerator\SnippetKeyGenerator;
 use LizardsAndPumpkins\DataPool\KeyValueStore\Snippet;
 use LizardsAndPumpkins\Import\SnippetRenderer;
 use LizardsAndPumpkins\Import\TemplateRendering\BlockRenderer;
+use LizardsAndPumpkins\Import\TemplateRendering\TemplateProjectionData;
 use LizardsAndPumpkins\ProductListing\ContentDelivery\ProductSearchResultMetaSnippetContent;
-use LizardsAndPumpkins\ProductListing\Import\TemplateRendering\TemplateProjectionData;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/Suites/Util/Factory/CommonFactoryTest.php
+++ b/tests/Unit/Suites/Util/Factory/CommonFactoryTest.php
@@ -54,7 +54,8 @@ use LizardsAndPumpkins\Messaging\Event\DomainEventHandlerLocator;
 use LizardsAndPumpkins\Messaging\Event\DomainEventQueue;
 use LizardsAndPumpkins\Messaging\Queue;
 use LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRenderer;
-use LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer;
+use LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer;
+use LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer;
 use LizardsAndPumpkins\ProductListing\AddProductListingCommandHandler;
 use LizardsAndPumpkins\ProductListing\Import\ProductListingBuilder;
 use LizardsAndPumpkins\ProductListing\Import\ProductListingSnippetRenderer;
@@ -102,7 +103,8 @@ use PHPUnit\Framework\TestCase;
  * @uses   \LizardsAndPumpkins\Import\Product\AttributeCode
  * @uses   \LizardsAndPumpkins\Import\Price\PriceSnippetRenderer
  * @uses   \LizardsAndPumpkins\Import\Product\ProductProjector
- * @uses   \LizardsAndPumpkins\ProductDetail\ProductDetailViewSnippetRenderer
+ * @uses   \LizardsAndPumpkins\ProductDetail\Import\ProductDetailTemplateSnippetRenderer
+ * @uses   \LizardsAndPumpkins\ProductDetail\ProductDetailMetaSnippetRenderer
  * @uses   \LizardsAndPumpkins\ProductListing\Import\ProductListingSnippetRenderer
  * @uses   \LizardsAndPumpkins\Import\GenericSnippetProjector
  * @uses   \LizardsAndPumpkins\ProductListing\Import\ProductListingProjector
@@ -233,9 +235,9 @@ class CommonFactoryTest extends TestCase
         $this->assertInstanceOf(ProductProjector::class, $result);
     }
 
-    public function testProductDetailViewSnippetKeyGeneratorIsReturned()
+    public function testProductDetailMetaSnippetKeyGeneratorIsReturned()
     {
-        $result = $this->commonFactory->createProductDetailViewSnippetKeyGenerator();
+        $result = $this->commonFactory->createProductDetailPageMetaSnippetKeyGenerator();
         $this->assertInstanceOf(SnippetKeyGenerator::class, $result);
     }
 
@@ -785,7 +787,7 @@ class CommonFactoryTest extends TestCase
     public function productSnippetRenderersProvider() : array
     {
         return [
-            [ProductDetailViewSnippetRenderer::class],
+            [ProductDetailMetaSnippetRenderer::class],
             [ProductInListingSnippetRenderer::class],
             [PriceSnippetRenderer::class],
             [ProductJsonSnippetRenderer::class],
@@ -819,6 +821,34 @@ class CommonFactoryTest extends TestCase
         return [
             [ProductListingTemplateSnippetRenderer::class],
             [ProductSearchResultMetaSnippetRenderer::class],
+        ];
+    }
+
+    /**
+     * @dataProvider productDetailTemplateSnippetRenderersProvider
+     */
+    public function testContainsProductDetailTemplateSnippetRenderersInSnippetRendererList(string $expected)
+    {
+        $found = array_reduce(
+            $this->commonFactory->createProductDetailTemplateSnippetRendererList(),
+            function ($found, SnippetRenderer $snippetRenderer) use ($expected) {
+                return $found || is_a($snippetRenderer, $expected);
+            }
+        );
+        $message = sprintf(
+            'SnippetRenderer "%s" not found in product detail template snippet renderer list',
+            $expected
+        );
+        $this->assertTrue($found, $message);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function productDetailTemplateSnippetRenderersProvider() : array
+    {
+        return [
+            [ProductDetailTemplateSnippetRenderer::class],
         ];
     }
 


### PR DESCRIPTION
Closes #261.

The following [patch](https://github.com/lizards-and-pumpkins/catalog/files/1042461/patch.txt) must be applied to sample project to work with product details root template.

Also template rendering must be include into provisioning script.