### PR TITLE
Issue #1073: Rename PageMetaInfoSnippetContent::getInfo into toArray

### DIFF
--- a/src/Import/PageMetaInfoSnippetContent.php
+++ b/src/Import/PageMetaInfoSnippetContent.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\Import;
 
-interface PageMetaInfoSnippetContent extends \JsonSerializable
+interface PageMetaInfoSnippetContent
 {
     const KEY_ROOT_SNIPPET_CODE = 'root_snippet_code';
     const KEY_PAGE_SNIPPET_CODES = 'page_snippet_codes';
     const KEY_CONTAINER_SNIPPETS = 'container_snippets';
     const URL_KEY = 'url_key';
+
+    /**
+     * @return mixed[]
+     */
+    public function toArray(): array;
 
     public function getRootSnippetCode(): string;
 

--- a/src/Import/PageMetaInfoSnippetContent.php
+++ b/src/Import/PageMetaInfoSnippetContent.php
@@ -4,27 +4,22 @@ declare(strict_types=1);
 
 namespace LizardsAndPumpkins\Import;
 
-interface PageMetaInfoSnippetContent
+interface PageMetaInfoSnippetContent extends \JsonSerializable
 {
     const KEY_ROOT_SNIPPET_CODE = 'root_snippet_code';
     const KEY_PAGE_SNIPPET_CODES = 'page_snippet_codes';
     const KEY_CONTAINER_SNIPPETS = 'container_snippets';
     const URL_KEY = 'url_key';
-    
-    /**
-     * @return mixed[]
-     */
-    public function getInfo() : array;
 
-    public function getRootSnippetCode() : string;
+    public function getRootSnippetCode(): string;
 
     /**
      * @return string[]
      */
-    public function getPageSnippetCodes() : array;
+    public function getPageSnippetCodes(): array;
 
     /**
      * @return array[]
      */
-    public function getContainerSnippets() : array;
+    public function getContainerSnippets(): array;
 }

--- a/src/ProductDetail/ProductDetailMetaSnippetRenderer.php
+++ b/src/ProductDetail/ProductDetailMetaSnippetRenderer.php
@@ -54,7 +54,7 @@ class ProductDetailMetaSnippetRenderer implements SnippetRenderer
      */
     private function createProductDetailPageMetaSnippets(ProductView $productView): array
     {
-        $pageMetaData = json_encode($this->getPageMetaSnippetContent($productView));
+        $pageMetaData = json_encode($this->getPageMetaSnippetContent($productView)->toArray());
         return array_map(function ($urlKey) use ($pageMetaData, $productView) {
             $key = $this->createPageMetaSnippetKey($urlKey, $productView);
             return Snippet::create($key, $pageMetaData);

--- a/src/ProductDetail/ProductDetailMetaSnippetRenderer.php
+++ b/src/ProductDetail/ProductDetailMetaSnippetRenderer.php
@@ -61,23 +61,16 @@ class ProductDetailMetaSnippetRenderer implements SnippetRenderer
         }, $this->getAllProductUrlKeys($productView));
     }
 
-    /**
-     * @param ProductView $productView
-     * @return mixed[]
-     */
-    private function getPageMetaSnippetContent(ProductView $productView): array
+    private function getPageMetaSnippetContent(ProductView $productView): ProductDetailPageMetaInfoSnippetContent
     {
         $this->blockRenderer->render($productView, $productView->getContext());
 
-        $rootBlockName = $this->blockRenderer->getRootSnippetCode();
-        $pageMetaInfo = ProductDetailPageMetaInfoSnippetContent::create(
+        return ProductDetailPageMetaInfoSnippetContent::create(
             (string) $productView->getId(),
-            $rootBlockName,
+            $this->blockRenderer->getRootSnippetCode(),
             $this->blockRenderer->getNestedSnippetCodes(),
             []
         );
-
-        return $pageMetaInfo->getInfo();
     }
 
     private function createPageMetaSnippetKey(string $urlKey, ProductView $productView): string

--- a/src/ProductDetail/ProductDetailPageMetaInfoSnippetContent.php
+++ b/src/ProductDetail/ProductDetailPageMetaInfoSnippetContent.php
@@ -60,7 +60,7 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
         string $rootSnippetCode,
         array $pageSnippetCodes,
         array $containerData
-    ) : ProductDetailPageMetaInfoSnippetContent {
+    ): ProductDetailPageMetaInfoSnippetContent {
         SnippetCodeValidator::validate($rootSnippetCode);
         $pageSnippetCodes = array_unique(array_merge(
             [
@@ -71,6 +71,7 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
             ],
             $pageSnippetCodes
         ));
+
         return new self($productId, $rootSnippetCode, $pageSnippetCodes, self::createSnippetContainers($containerData));
     }
 
@@ -78,17 +79,18 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
      * @param array[] $containerArray
      * @return SnippetContainer[]
      */
-    private static function createSnippetContainers(array $containerArray) : array
+    private static function createSnippetContainers(array $containerArray): array
     {
         return array_map(function ($code) use ($containerArray) {
             return new SnippetContainer($code, $containerArray[$code]);
         }, array_keys($containerArray));
     }
 
-    public static function fromJson(string $json) : ProductDetailPageMetaInfoSnippetContent
+    public static function fromJson(string $json): ProductDetailPageMetaInfoSnippetContent
     {
         $pageInfo = self::decodeJson($json);
         self::validateRequiredKeysArePresent($pageInfo);
+
         return static::create(
             $pageInfo[self::KEY_PRODUCT_ID],
             $pageInfo[self::KEY_ROOT_SNIPPET_CODE],
@@ -113,7 +115,7 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
      * @param string $json
      * @return mixed[]
      */
-    private static function decodeJson(string $json) : array
+    private static function decodeJson(string $json): array
     {
         $result = json_decode($json, true);
 
@@ -127,7 +129,7 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
     /**
      * @return mixed[]
      */
-    public function getInfo() : array
+    public function jsonSerialize(): array
     {
         return [
             self::KEY_PRODUCT_ID => $this->productId,
@@ -137,15 +139,12 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getProductId() : string
+    public function getProductId(): string
     {
         return $this->productId;
     }
 
-    public function getRootSnippetCode() : string
+    public function getRootSnippetCode(): string
     {
         return $this->rootSnippetCode;
     }
@@ -153,7 +152,7 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
     /**
      * @return string[]
      */
-    public function getPageSnippetCodes() : array
+    public function getPageSnippetCodes(): array
     {
         return $this->pageSnippetCodes;
     }
@@ -161,7 +160,7 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
     /**
      * @return array[]
      */
-    public function getContainerSnippets() : array
+    public function getContainerSnippets(): array
     {
         return array_reduce($this->containers, function ($carry, SnippetContainer $container) {
             return array_merge($carry, $container->toArray());

--- a/src/ProductDetail/ProductDetailPageMetaInfoSnippetContent.php
+++ b/src/ProductDetail/ProductDetailPageMetaInfoSnippetContent.php
@@ -129,7 +129,7 @@ class ProductDetailPageMetaInfoSnippetContent implements PageMetaInfoSnippetCont
     /**
      * @return mixed[]
      */
-    public function jsonSerialize(): array
+    public function toArray(): array
     {
         return [
             self::KEY_PRODUCT_ID => $this->productId,

--- a/src/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContent.php
+++ b/src/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContent.php
@@ -91,7 +91,7 @@ class ProductSearchResultMetaSnippetContent implements PageMetaInfoSnippetConten
     /**
      * @return mixed[]
      */
-    public function jsonSerialize(): array
+    public function toArray(): array
     {
         return [
             self::KEY_ROOT_SNIPPET_CODE => $this->rootSnippetCode,

--- a/src/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContent.php
+++ b/src/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContent.php
@@ -91,7 +91,7 @@ class ProductSearchResultMetaSnippetContent implements PageMetaInfoSnippetConten
     /**
      * @return mixed[]
      */
-    public function getInfo() : array
+    public function jsonSerialize(): array
     {
         return [
             self::KEY_ROOT_SNIPPET_CODE => $this->rootSnippetCode,

--- a/src/ProductListing/Import/ProductListingSnippetContent.php
+++ b/src/ProductListing/Import/ProductListingSnippetContent.php
@@ -140,7 +140,7 @@ class ProductListingSnippetContent implements PageMetaInfoSnippetContent
     /**
      * @return mixed[]
      */
-    public function jsonSerialize() : array
+    public function toArray() : array
     {
         return [
             self::KEY_CRITERIA => $this->selectionCriteria,

--- a/src/ProductListing/Import/ProductListingSnippetContent.php
+++ b/src/ProductListing/Import/ProductListingSnippetContent.php
@@ -115,7 +115,7 @@ class ProductListingSnippetContent implements PageMetaInfoSnippetContent
     /**
      * @param mixed[] $pageInfo
      */
-    protected static function validateRequiredKeysArePresent(array $pageInfo)
+    private static function validateRequiredKeysArePresent(array $pageInfo)
     {
         foreach (self::$requiredKeys as $key) {
             if (! array_key_exists($key, $pageInfo)) {

--- a/src/ProductListing/Import/ProductListingSnippetContent.php
+++ b/src/ProductListing/Import/ProductListingSnippetContent.php
@@ -140,7 +140,7 @@ class ProductListingSnippetContent implements PageMetaInfoSnippetContent
     /**
      * @return mixed[]
      */
-    public function getInfo() : array
+    public function jsonSerialize() : array
     {
         return [
             self::KEY_CRITERIA => $this->selectionCriteria,

--- a/src/ProductListing/Import/ProductListingSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductListingSnippetRenderer.php
@@ -62,7 +62,7 @@ class ProductListingSnippetRenderer implements SnippetRenderer
     private function createPageMetaSnippet(ProductListing $productListing): Snippet
     {
         $metaDataSnippetKey = $this->getProductListingMetaDataSnippetKey($productListing);
-        $metaDataSnippetContent = $this->getProductListingPageMetaInfoSnippetContent($productListing);
+        $metaDataSnippetContent = json_encode($this->getPageMetaInfoSnippetContent($productListing));
         return Snippet::create($metaDataSnippetKey, $metaDataSnippetContent);
     }
 
@@ -77,16 +77,14 @@ class ProductListingSnippetRenderer implements SnippetRenderer
         return $snippetKey;
     }
 
-    private function getProductListingPageMetaInfoSnippetContent(ProductListing $productListing): string
+    private function getPageMetaInfoSnippetContent(ProductListing $productListing): ProductListingSnippetContent
     {
-        $metaSnippetContent = ProductListingSnippetContent::create(
+        return ProductListingSnippetContent::create(
             $productListing->getCriteria(),
             ProductListingTemplateSnippetRenderer::CODE,
             $this->getPageSnippetCodes($productListing),
             []
         );
-
-        return json_encode($metaSnippetContent->getInfo());
     }
 
     /**

--- a/src/ProductListing/Import/ProductListingSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductListingSnippetRenderer.php
@@ -62,7 +62,7 @@ class ProductListingSnippetRenderer implements SnippetRenderer
     private function createPageMetaSnippet(ProductListing $productListing): Snippet
     {
         $metaDataSnippetKey = $this->getProductListingMetaDataSnippetKey($productListing);
-        $metaDataSnippetContent = json_encode($this->getPageMetaInfoSnippetContent($productListing));
+        $metaDataSnippetContent = json_encode($this->getPageMetaInfoSnippetContent($productListing)->toArray());
         return Snippet::create($metaDataSnippetKey, $metaDataSnippetContent);
     }
 

--- a/src/ProductListing/Import/ProductSearchResultMetaSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductSearchResultMetaSnippetRenderer.php
@@ -66,7 +66,7 @@ class ProductSearchResultMetaSnippetRenderer implements SnippetRenderer
         $pageSnippetCodes = $this->blockRenderer->getNestedSnippetCodes();
 
         $metaSnippetKey = $this->snippetKeyGenerator->getKeyForContext($context, []);
-        $metaSnippetContent = json_encode($this->getMetaSnippetContent($rootSnippetCode, $pageSnippetCodes));
+        $metaSnippetContent = json_encode($this->getMetaSnippetContent($rootSnippetCode, $pageSnippetCodes)->toArray());
 
         return Snippet::create($metaSnippetKey, $metaSnippetContent);
     }

--- a/src/ProductListing/Import/ProductSearchResultMetaSnippetRenderer.php
+++ b/src/ProductListing/Import/ProductSearchResultMetaSnippetRenderer.php
@@ -66,7 +66,7 @@ class ProductSearchResultMetaSnippetRenderer implements SnippetRenderer
         $pageSnippetCodes = $this->blockRenderer->getNestedSnippetCodes();
 
         $metaSnippetKey = $this->snippetKeyGenerator->getKeyForContext($context, []);
-        $metaSnippetContent = $this->getMetaSnippetContentJson($rootSnippetCode, $pageSnippetCodes);
+        $metaSnippetContent = json_encode($this->getMetaSnippetContent($rootSnippetCode, $pageSnippetCodes));
 
         return Snippet::create($metaSnippetKey, $metaSnippetContent);
     }
@@ -74,11 +74,12 @@ class ProductSearchResultMetaSnippetRenderer implements SnippetRenderer
     /**
      * @param string $rootSnippetCode
      * @param string[] $pageSnippetCodes
-     * @return ProductSearchResultMetaSnippetContent|string
+     * @return ProductSearchResultMetaSnippetContent
      */
-    private function getMetaSnippetContentJson(string $rootSnippetCode, array $pageSnippetCodes)
-    {
-        $metaSnippetContent = ProductSearchResultMetaSnippetContent::create($rootSnippetCode, $pageSnippetCodes, []);
-        return json_encode($metaSnippetContent->getInfo());
+    private function getMetaSnippetContent(
+        string $rootSnippetCode,
+        array $pageSnippetCodes
+    ) : ProductSearchResultMetaSnippetContent {
+        return ProductSearchResultMetaSnippetContent::create($rootSnippetCode, $pageSnippetCodes, []);
     }
 }

--- a/tests/Integration/Suites/FrontendRenderingTest.php
+++ b/tests/Integration/Suites/FrontendRenderingTest.php
@@ -60,7 +60,7 @@ class FrontendRenderingTest extends AbstractIntegrationTest
             ['head', 'body'],
             []
         );
-        $metaInfoSnippet = Snippet::create($productDetailPageMetaSnippetKey, json_encode($pageMetaInfo));
+        $metaInfoSnippet = Snippet::create($productDetailPageMetaSnippetKey, json_encode($pageMetaInfo->toArray()));
 
         $rootSnippetContent = '<html><head>{{snippet head}}</head><body>{{snippet body}}</body></html>';
         $rootSnippet = Snippet::create($this->getSnippetKey($rootSnippetCode, $context), $rootSnippetContent);

--- a/tests/Integration/Suites/FrontendRenderingTest.php
+++ b/tests/Integration/Suites/FrontendRenderingTest.php
@@ -60,7 +60,7 @@ class FrontendRenderingTest extends AbstractIntegrationTest
             ['head', 'body'],
             []
         );
-        $metaInfoSnippet = Snippet::create($productDetailPageMetaSnippetKey, json_encode($pageMetaInfo->getInfo()));
+        $metaInfoSnippet = Snippet::create($productDetailPageMetaSnippetKey, json_encode($pageMetaInfo));
 
         $rootSnippetContent = '<html><head>{{snippet head}}</head><body>{{snippet body}}</body></html>';
         $rootSnippet = Snippet::create($this->getSnippetKey($rootSnippetCode, $context), $rootSnippetContent);

--- a/tests/Unit/Suites/ProductDetail/ProductDetailPageMetaInfoSnippetContentTest.php
+++ b/tests/Unit/Suites/ProductDetail/ProductDetailPageMetaInfoSnippetContentTest.php
@@ -42,9 +42,9 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
         );
     }
 
-    public function testPageMetaInfoIsAnArray()
+    public function testCanBeJsonEncoded()
     {
-        $this->assertInternalType('array', $this->pageMetaInfo->getInfo());
+        $this->assertInternalType('array', $this->pageMetaInfo->jsonSerialize());
     }
 
     public function testExpectedArrayKeysArePresentInJsonContent()
@@ -57,7 +57,7 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
         ];
         foreach ($keys as $key) {
             $this->assertTrue(
-                array_key_exists($key, $this->pageMetaInfo->getInfo()),
+                array_key_exists($key, $this->pageMetaInfo->jsonSerialize()),
                 sprintf('The expected key "%s" is not set on the page meta info array', $key)
             );
         }
@@ -87,7 +87,7 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
 
     public function testFromJsonConstructorIsPresent()
     {
-        $pageMetaInfo = ProductDetailPageMetaInfoSnippetContent::fromJson(json_encode($this->pageMetaInfo->getInfo()));
+        $pageMetaInfo = ProductDetailPageMetaInfoSnippetContent::fromJson(json_encode($this->pageMetaInfo));
         $this->assertInstanceOf(ProductDetailPageMetaInfoSnippetContent::class, $pageMetaInfo);
     }
 
@@ -104,7 +104,7 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Missing key in input JSON');
-        $pageInfo = $this->pageMetaInfo->getInfo();
+        $pageInfo = $this->pageMetaInfo->jsonSerialize();
         unset($pageInfo[$key]);
         ProductDetailPageMetaInfoSnippetContent::fromJson(json_encode($pageInfo));
     }

--- a/tests/Unit/Suites/ProductDetail/ProductDetailPageMetaInfoSnippetContentTest.php
+++ b/tests/Unit/Suites/ProductDetail/ProductDetailPageMetaInfoSnippetContentTest.php
@@ -42,9 +42,9 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
         );
     }
 
-    public function testCanBeJsonEncoded()
+    public function testReturnsPageMetaSnippetAsArray()
     {
-        $this->assertInternalType('array', $this->pageMetaInfo->jsonSerialize());
+        $this->assertInternalType('array', $this->pageMetaInfo->toArray());
     }
 
     public function testExpectedArrayKeysArePresentInJsonContent()
@@ -57,7 +57,7 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
         ];
         foreach ($keys as $key) {
             $this->assertTrue(
-                array_key_exists($key, $this->pageMetaInfo->jsonSerialize()),
+                array_key_exists($key, $this->pageMetaInfo->toArray()),
                 sprintf('The expected key "%s" is not set on the page meta info array', $key)
             );
         }
@@ -87,7 +87,7 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
 
     public function testFromJsonConstructorIsPresent()
     {
-        $pageMetaInfo = ProductDetailPageMetaInfoSnippetContent::fromJson(json_encode($this->pageMetaInfo));
+        $pageMetaInfo = ProductDetailPageMetaInfoSnippetContent::fromJson(json_encode($this->pageMetaInfo->toArray()));
         $this->assertInstanceOf(ProductDetailPageMetaInfoSnippetContent::class, $pageMetaInfo);
     }
 
@@ -104,7 +104,7 @@ class ProductDetailPageMetaInfoSnippetContentTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Missing key in input JSON');
-        $pageInfo = $this->pageMetaInfo->jsonSerialize();
+        $pageInfo = $this->pageMetaInfo->toArray();
         unset($pageInfo[$key]);
         ProductDetailPageMetaInfoSnippetContent::fromJson(json_encode($pageInfo));
     }

--- a/tests/Unit/Suites/ProductDetail/ProductDetailViewRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductDetail/ProductDetailViewRequestHandlerTest.php
@@ -95,7 +95,7 @@ class ProductDetailViewRequestHandlerTest extends TestCase
             'root-snippet-code',
             ['child-snippet1'],
             []
-        ));
+        )->toArray());
     }
 
     private function assertDynamicSnippetWasAddedToPageBuilder(string $snippetCode, string $snippetValue)

--- a/tests/Unit/Suites/ProductDetail/ProductDetailViewRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductDetail/ProductDetailViewRequestHandlerTest.php
@@ -95,7 +95,7 @@ class ProductDetailViewRequestHandlerTest extends TestCase
             'root-snippet-code',
             ['child-snippet1'],
             []
-        )->getInfo());
+        ));
     }
 
     private function assertDynamicSnippetWasAddedToPageBuilder(string $snippetCode, string $snippetValue)

--- a/tests/Unit/Suites/ProductListing/ContentDelivery/ProductListingRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductListing/ContentDelivery/ProductListingRequestHandlerTest.php
@@ -77,7 +77,7 @@ class ProductListingRequestHandlerTest extends TestCase
             'root-snippet-code',
             $pageSnippetCodes,
             []
-        ));
+        )->toArray());
 
         $stubSearchEngineResponse = $this->createMock(SearchEngineResponse::class);
         $stubSearchEngineResponse->method('getTotalNumberOfResults')->willReturn($numberOfResults);

--- a/tests/Unit/Suites/ProductListing/ContentDelivery/ProductListingRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductListing/ContentDelivery/ProductListingRequestHandlerTest.php
@@ -77,7 +77,7 @@ class ProductListingRequestHandlerTest extends TestCase
             'root-snippet-code',
             $pageSnippetCodes,
             []
-        )->getInfo());
+        ));
 
         $stubSearchEngineResponse = $this->createMock(SearchEngineResponse::class);
         $stubSearchEngineResponse->method('getTotalNumberOfResults')->willReturn($numberOfResults);

--- a/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchRequestHandlerTest.php
@@ -67,7 +67,7 @@ class ProductSearchRequestHandlerTest extends TestCase
             'root-snippet-code',
             $pageSnippetCodes,
             []
-        ));
+        )->toArray());
 
         $stubSearchEngineResponse = $this->createMock(SearchEngineResponse::class);
 

--- a/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchRequestHandlerTest.php
+++ b/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchRequestHandlerTest.php
@@ -67,7 +67,7 @@ class ProductSearchRequestHandlerTest extends TestCase
             'root-snippet-code',
             $pageSnippetCodes,
             []
-        )->getInfo());
+        ));
 
         $stubSearchEngineResponse = $this->createMock(SearchEngineResponse::class);
 

--- a/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContentTest.php
+++ b/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContentTest.php
@@ -55,7 +55,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
             ProductSearchResultMetaSnippetContent::KEY_CONTAINER_SNIPPETS,
         ];
 
-        $result = $this->metaSnippetContent->getInfo();
+        $result = $this->metaSnippetContent->jsonSerialize();
 
         foreach ($expectedKeys as $key) {
             $this->assertArrayHasKey($key, $result, sprintf('Page meta info array is lacking "%s" key', $key));
@@ -75,7 +75,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
     public function testRootSnippetCodeIsAddedToTheSnippetCodeListIfAbsent()
     {
         $metaSnippetContent = ProductSearchResultMetaSnippetContent::create($this->dummyRootSnippetCode, [], []);
-        $metaMetaInfo = $metaSnippetContent->getInfo();
+        $metaMetaInfo = $metaSnippetContent->jsonSerialize();
         $pageSnippetCodes = $metaMetaInfo[ProductSearchResultMetaSnippetContent::KEY_PAGE_SNIPPET_CODES];
 
         $this->assertContains($this->dummyRootSnippetCode, $pageSnippetCodes);
@@ -83,7 +83,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
 
     public function testCanBeCreatedFromJson()
     {
-        $jsonEncodedPageMetaInfo = json_encode($this->metaSnippetContent->getInfo());
+        $jsonEncodedPageMetaInfo = json_encode($this->metaSnippetContent);
         $metaSnippetContent = ProductSearchResultMetaSnippetContent::fromJson($jsonEncodedPageMetaInfo);
         $this->assertInstanceOf(ProductSearchResultMetaSnippetContent::class, $metaSnippetContent);
     }
@@ -93,7 +93,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
      */
     public function testExceptionIsThrownIfJsonDoesNotContainRequiredData(string $missingKey)
     {
-        $pageMetaInfo = $this->metaSnippetContent->getInfo();
+        $pageMetaInfo = $this->metaSnippetContent->jsonSerialize();
         unset($pageMetaInfo[$missingKey]);
 
         $this->expectException(\RuntimeException::class);

--- a/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContentTest.php
+++ b/tests/Unit/Suites/ProductListing/ContentDelivery/ProductSearchResultMetaSnippetContentTest.php
@@ -55,7 +55,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
             ProductSearchResultMetaSnippetContent::KEY_CONTAINER_SNIPPETS,
         ];
 
-        $result = $this->metaSnippetContent->jsonSerialize();
+        $result = $this->metaSnippetContent->toArray();
 
         foreach ($expectedKeys as $key) {
             $this->assertArrayHasKey($key, $result, sprintf('Page meta info array is lacking "%s" key', $key));
@@ -75,7 +75,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
     public function testRootSnippetCodeIsAddedToTheSnippetCodeListIfAbsent()
     {
         $metaSnippetContent = ProductSearchResultMetaSnippetContent::create($this->dummyRootSnippetCode, [], []);
-        $metaMetaInfo = $metaSnippetContent->jsonSerialize();
+        $metaMetaInfo = $metaSnippetContent->toArray();
         $pageSnippetCodes = $metaMetaInfo[ProductSearchResultMetaSnippetContent::KEY_PAGE_SNIPPET_CODES];
 
         $this->assertContains($this->dummyRootSnippetCode, $pageSnippetCodes);
@@ -83,7 +83,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
 
     public function testCanBeCreatedFromJson()
     {
-        $jsonEncodedPageMetaInfo = json_encode($this->metaSnippetContent);
+        $jsonEncodedPageMetaInfo = json_encode($this->metaSnippetContent->toArray());
         $metaSnippetContent = ProductSearchResultMetaSnippetContent::fromJson($jsonEncodedPageMetaInfo);
         $this->assertInstanceOf(ProductSearchResultMetaSnippetContent::class, $metaSnippetContent);
     }
@@ -93,7 +93,7 @@ class ProductSearchResultMetaSnippetContentTest extends TestCase
      */
     public function testExceptionIsThrownIfJsonDoesNotContainRequiredData(string $missingKey)
     {
-        $pageMetaInfo = $this->metaSnippetContent->jsonSerialize();
+        $pageMetaInfo = $this->metaSnippetContent->toArray();
         unset($pageMetaInfo[$missingKey]);
 
         $this->expectException(\RuntimeException::class);

--- a/tests/Unit/Suites/ProductListing/Import/ProductListingSnippetContentTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/ProductListingSnippetContentTest.php
@@ -60,9 +60,9 @@ class ProductListingSnippetContentTest extends TestCase
         );
     }
 
-    public function testArrayIsReturned()
+    public function testCanBeJsonSerializes()
     {
-        $this->assertInternalType('array', $this->pageMetaInfo->getInfo());
+        $this->assertInternalType('array', $this->pageMetaInfo->jsonSerialize());
     }
 
     public function testExpectedArrayKeysArePresentInJsonContent()
@@ -74,7 +74,7 @@ class ProductListingSnippetContentTest extends TestCase
             ProductListingSnippetContent::KEY_CONTAINER_SNIPPETS,
         ];
 
-        $result = $this->pageMetaInfo->getInfo();
+        $result = $this->pageMetaInfo->jsonSerialize();
 
         foreach ($keys as $key) {
             $this->assertArrayHasKey($key, $result, sprintf('Page meta info array is lacking "%s" key', $key));
@@ -98,13 +98,13 @@ class ProductListingSnippetContentTest extends TestCase
         );
         $this->assertContains(
             $rootSnippetCode,
-            $pageMetaInfo->getInfo()[ProductListingSnippetContent::KEY_PAGE_SNIPPET_CODES]
+            $pageMetaInfo->jsonSerialize()[ProductListingSnippetContent::KEY_PAGE_SNIPPET_CODES]
         );
     }
 
     public function testJsonConstructorIsPresent()
     {
-        $pageMetaInfo = ProductListingSnippetContent::fromJson(json_encode($this->pageMetaInfo->getInfo()));
+        $pageMetaInfo = ProductListingSnippetContent::fromJson(json_encode($this->pageMetaInfo));
         $this->assertInstanceOf(ProductListingSnippetContent::class, $pageMetaInfo);
     }
 
@@ -121,7 +121,7 @@ class ProductListingSnippetContentTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Missing key in input JSON');
-        $pageInfo = $this->pageMetaInfo->getInfo();
+        $pageInfo = $this->pageMetaInfo->jsonSerialize();
         unset($pageInfo[$key]);
         ProductListingSnippetContent::fromJson(json_encode($pageInfo));
     }

--- a/tests/Unit/Suites/ProductListing/Import/ProductListingSnippetContentTest.php
+++ b/tests/Unit/Suites/ProductListing/Import/ProductListingSnippetContentTest.php
@@ -60,9 +60,9 @@ class ProductListingSnippetContentTest extends TestCase
         );
     }
 
-    public function testCanBeJsonSerializes()
+    public function testReturnsPageMetaSnippetAsArray()
     {
-        $this->assertInternalType('array', $this->pageMetaInfo->jsonSerialize());
+        $this->assertInternalType('array', $this->pageMetaInfo->toArray());
     }
 
     public function testExpectedArrayKeysArePresentInJsonContent()
@@ -74,7 +74,7 @@ class ProductListingSnippetContentTest extends TestCase
             ProductListingSnippetContent::KEY_CONTAINER_SNIPPETS,
         ];
 
-        $result = $this->pageMetaInfo->jsonSerialize();
+        $result = $this->pageMetaInfo->toArray();
 
         foreach ($keys as $key) {
             $this->assertArrayHasKey($key, $result, sprintf('Page meta info array is lacking "%s" key', $key));
@@ -98,13 +98,13 @@ class ProductListingSnippetContentTest extends TestCase
         );
         $this->assertContains(
             $rootSnippetCode,
-            $pageMetaInfo->jsonSerialize()[ProductListingSnippetContent::KEY_PAGE_SNIPPET_CODES]
+            $pageMetaInfo->toArray()[ProductListingSnippetContent::KEY_PAGE_SNIPPET_CODES]
         );
     }
 
     public function testJsonConstructorIsPresent()
     {
-        $pageMetaInfo = ProductListingSnippetContent::fromJson(json_encode($this->pageMetaInfo));
+        $pageMetaInfo = ProductListingSnippetContent::fromJson(json_encode($this->pageMetaInfo->toArray()));
         $this->assertInstanceOf(ProductListingSnippetContent::class, $pageMetaInfo);
     }
 
@@ -121,7 +121,7 @@ class ProductListingSnippetContentTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Missing key in input JSON');
-        $pageInfo = $this->pageMetaInfo->jsonSerialize();
+        $pageInfo = $this->pageMetaInfo->toArray();
         unset($pageInfo[$key]);
         ProductListingSnippetContent::fromJson(json_encode($pageInfo));
     }


### PR DESCRIPTION
It fall into my eye that `getInfo` method was only used to be than passed to `json_encode`.