### PR TITLE
#1109: Fixes broken exception if sku is numeric only

### DIFF
--- a/src/Import/Product/Composite/AssociatedProductList.php
+++ b/src/Import/Product/Composite/AssociatedProductList.php
@@ -124,7 +124,7 @@ class AssociatedProductList implements \JsonSerializable, \IteratorAggregate, \C
                     ...$attributeCodes
                 );
             }
-            return array_merge($carry, [(string) $product->getId() => $attributeValuesForProduct]);
+            return ($carry + [(string) $product->getId() => $attributeValuesForProduct]);
         }, []);
     }
 

--- a/src/Import/Product/Composite/AssociatedProductList.php
+++ b/src/Import/Product/Composite/AssociatedProductList.php
@@ -119,7 +119,7 @@ class AssociatedProductList implements \JsonSerializable, \IteratorAggregate, \C
             $otherProductId = array_search($attributeValuesForProduct, $carry);
             if (false !== $otherProductId) {
                 throw $this->createProductAttributeValueCombinationNotUniqueException(
-                    $otherProductId,
+                    (string) $otherProductId,
                     (string) $product->getId(),
                     ...$attributeCodes
                 );

--- a/tests/Unit/Suites/Import/Product/Composite/AssociatedProductListTest.php
+++ b/tests/Unit/Suites/Import/Product/Composite/AssociatedProductListTest.php
@@ -191,6 +191,33 @@ class AssociatedProductListTest extends TestCase
         );
     }
 
+    public function testItThrowsAnExceptionIfTheValueCombinationsForTheGivenAttributesAreNotUniqueAndSkuIsNumeric()
+    {
+        $this->expectException(ProductAttributeValueCombinationNotUniqueException::class);
+        $this->expectExceptionMessage(
+            'The associated products "test1" and "test2" have the same value combination ' .
+            'for the attributes "code_a" and "code_b"'
+        );
+
+        $dummyAttributeCodeA = AttributeCode::fromString('code_a');
+        $dummyAttributeCodeB = AttributeCode::fromString('code_b');
+
+        $fooAttribute1 = $this->createStubAttribute($dummyAttributeCodeA, 'foo1');
+        $fooAttribute2 = $this->createStubAttribute($dummyAttributeCodeA, 'foo1');
+        $barAttribute1 = $this->createStubAttribute($dummyAttributeCodeB, 'bar1');
+        $barAttribute2 = $this->createStubAttribute($dummyAttributeCodeB, 'bar1');
+
+        $stubProductOne = $this->createStubProduct('4711', $fooAttribute1, $barAttribute1);
+        $stubProductTwo = $this->createStubProduct('1337', $fooAttribute2, $barAttribute2);
+
+        $associatedProductList = new AssociatedProductList($stubProductOne, $stubProductTwo);
+
+        $associatedProductList->validateUniqueValueCombinationForEachProductAttribute(
+            $dummyAttributeCodeA,
+            $dummyAttributeCodeB
+        );
+    }
+
     public function testItThrowsNoExceptionIfTheValueCombinationsForTheGivenAttributesAreUnique()
     {
         $dummyAttributeCodeA = AttributeCode::fromString('code_a');

--- a/tests/Unit/Suites/Import/Product/Composite/AssociatedProductListTest.php
+++ b/tests/Unit/Suites/Import/Product/Composite/AssociatedProductListTest.php
@@ -195,7 +195,7 @@ class AssociatedProductListTest extends TestCase
     {
         $this->expectException(ProductAttributeValueCombinationNotUniqueException::class);
         $this->expectExceptionMessage(
-            'The associated products "test1" and "test2" have the same value combination ' .
+            'The associated products "4711" and "1337" have the same value combination ' .
             'for the attributes "code_a" and "code_b"'
         );
 


### PR DESCRIPTION
PHP translates the '4711' to 4711 and array_merge reindexes the numeric only keys and kills the product id finally.